### PR TITLE
#16 Fix bug where removing FormControls causes FormControlNotFoundException

### DIFF
--- a/generator_tests/pubspec.lock
+++ b/generator_tests/pubspec.lock
@@ -409,14 +409,14 @@ packages:
       path: "../packages/reactive_forms_annotations"
       relative: true
     source: path
-    version: "0.2.0-beta"
+    version: "0.3.1-beta"
   reactive_forms_generator:
     dependency: "direct dev"
     description:
       path: "../packages/reactive_forms_generator"
       relative: true
     source: path
-    version: "0.5.0-beta"
+    version: "0.6.1-beta"
   recase:
     dependency: "direct main"
     description:

--- a/packages/reactive_forms_generator/example/lib/docs/array_group/delivery_list.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/array_group/delivery_list.gform.dart
@@ -150,24 +150,25 @@ class DeliveryListForm implements FormModel<DeliveryList> {
   late List<DeliveryPointForm> deliveryListDeliveryPointForm;
 
   String deliveryListControlPath() => pathBuilder(deliveryListControlName);
-  List<DeliveryPoint> get deliveryListValue => (deliveryListControl.value ?? [])
-      .asMap()
-      .map((k, v) => MapEntry(
-          k,
-          DeliveryPointForm(
-                  DeliveryPoint(), form, pathBuilder("deliveryList.$k"))
-              .model))
-      .values
-      .toList();
+  List<DeliveryPoint> get deliveryListValue =>
+      (deliveryListControl?.value ?? [])
+          .asMap()
+          .map((k, v) => MapEntry(
+              k,
+              DeliveryPointForm(
+                      DeliveryPoint(), form, pathBuilder("deliveryList.$k"))
+                  .model))
+          .values
+          .toList();
   bool get containsDeliveryList => form.contains(deliveryListControlPath());
-  Object? get deliveryListErrors => deliveryListControl.errors;
+  Object? get deliveryListErrors => deliveryListControl?.errors;
   void get deliveryListFocus => form.focus(deliveryListControlPath());
   void deliveryListRemove({bool updateParent = true, bool emitEvent = true}) =>
       form.removeControl(deliveryListControlPath(),
           updateParent: updateParent, emitEvent: emitEvent);
   void deliveryListValueUpdate(List<DeliveryPoint> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      deliveryListControl.updateValue(
+      deliveryListControl?.updateValue(
           value
               .map((e) => DeliveryPointForm(e, FormGroup({}), null)
                   .formElements()
@@ -177,7 +178,7 @@ class DeliveryListForm implements FormModel<DeliveryList> {
           emitEvent: emitEvent);
   void deliveryListValuePatch(List<DeliveryPoint> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      deliveryListControl.patchValue(
+      deliveryListControl?.patchValue(
           value
               .map((e) => DeliveryPointForm(e, FormGroup({}), null)
                   .formElements()
@@ -190,7 +191,7 @@ class DeliveryListForm implements FormModel<DeliveryList> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      deliveryListControl.reset(
+      deliveryListControl?.reset(
           value: value
               .map((e) => DeliveryPointForm(e, FormGroup({}), null)
                   .formElements()
@@ -198,15 +199,19 @@ class DeliveryListForm implements FormModel<DeliveryList> {
               .toList(),
           updateParent: updateParent,
           emitEvent: emitEvent);
-  FormArray<Map<String, Object?>> get deliveryListControl =>
-      form.control(deliveryListControlPath())
-          as FormArray<Map<String, Object?>>;
+  FormArray<Map<String, Object?>>? get deliveryListControl {
+    if (containsDeliveryList) {
+      return form.control(deliveryListControlPath())
+          as FormArray<Map<String, Object?>>?;
+    }
+  }
+
   void addDeliveryListItem(DeliveryPoint value) {
     final formGroup =
         DeliveryPointForm(value, form, pathBuilder('deliveryList'))
             .formElements();
 
-    deliveryListControl.add(formGroup);
+    deliveryListControl?.add(formGroup);
   }
 
   DeliveryList get model => DeliveryList(deliveryList: deliveryListValue);
@@ -264,12 +269,12 @@ class DeliveryPointForm implements FormModel<DeliveryPoint> {
 
   String nameControlPath() => pathBuilder(nameControlName);
   String addressControlPath() => pathBuilder(addressControlName);
-  String get nameValue => nameControl.value as String;
+  String get nameValue => nameControl?.value as String;
   Address? get addressValue => addressForm.model;
   bool get containsName => form.contains(nameControlPath());
   bool get containsAddress => form.contains(addressControlPath());
-  Object? get nameErrors => nameControl.errors;
-  Object? get addressErrors => addressControl.errors;
+  Object? get nameErrors => nameControl?.errors;
+  Object? get addressErrors => addressControl?.errors;
   void get nameFocus => form.focus(nameControlPath());
   void get addressFocus => form.focus(addressControlPath());
   void nameRemove({bool updateParent = true, bool emitEvent = true}) =>
@@ -280,21 +285,21 @@ class DeliveryPointForm implements FormModel<DeliveryPoint> {
           updateParent: updateParent, emitEvent: emitEvent);
   void nameValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      nameControl.updateValue(value,
+      nameControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void addressValueUpdate(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      addressControl.updateValue(
+      addressControl?.updateValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void nameValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      nameControl.patchValue(value,
+      nameControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void addressValuePatch(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      addressControl.patchValue(
+      addressControl?.patchValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
@@ -303,22 +308,30 @@ class DeliveryPointForm implements FormModel<DeliveryPoint> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      nameControl.reset(
+      nameControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void addressValueReset(Address? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      addressControl.reset(
+      addressControl?.reset(
           value:
               AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
-  FormControl<String> get nameControl =>
-      form.control(nameControlPath()) as FormControl<String>;
-  FormGroup get addressControl =>
-      form.control(addressControlPath()) as FormGroup;
+  FormControl<String>? get nameControl {
+    if (containsName) {
+      return form.control(nameControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormGroup? get addressControl {
+    if (containsAddress) {
+      return form.control(addressControlPath()) as FormGroup?;
+    }
+  }
+
   DeliveryPoint get model =>
       DeliveryPoint(name: nameValue, address: addressValue);
   void updateValue(DeliveryPoint value,
@@ -372,12 +385,12 @@ class AddressForm implements FormModel<Address> {
 
   String streetControlPath() => pathBuilder(streetControlName);
   String cityControlPath() => pathBuilder(cityControlName);
-  String? get streetValue => streetControl.value;
-  String? get cityValue => cityControl.value;
+  String? get streetValue => streetControl?.value;
+  String? get cityValue => cityControl?.value;
   bool get containsStreet => form.contains(streetControlPath());
   bool get containsCity => form.contains(cityControlPath());
-  Object? get streetErrors => streetControl.errors;
-  Object? get cityErrors => cityControl.errors;
+  Object? get streetErrors => streetControl?.errors;
+  Object? get cityErrors => cityControl?.errors;
   void get streetFocus => form.focus(streetControlPath());
   void get cityFocus => form.focus(cityControlPath());
   void streetRemove({bool updateParent = true, bool emitEvent = true}) =>
@@ -388,38 +401,46 @@ class AddressForm implements FormModel<Address> {
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      streetControl.updateValue(value,
+      streetControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void cityValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      cityControl.updateValue(value,
+      cityControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      streetControl.patchValue(value,
+      streetControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void cityValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      cityControl.patchValue(value,
+      cityControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      streetControl.reset(
+      streetControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void cityValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      cityControl.reset(
+      cityControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get streetControl =>
-      form.control(streetControlPath()) as FormControl<String>;
-  FormControl<String> get cityControl =>
-      form.control(cityControlPath()) as FormControl<String>;
+  FormControl<String>? get streetControl {
+    if (containsStreet) {
+      return form.control(streetControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get cityControl {
+    if (containsCity) {
+      return form.control(cityControlPath()) as FormControl<String>?;
+    }
+  }
+
   Address get model => Address(street: streetValue, city: cityValue);
   void updateValue(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>

--- a/packages/reactive_forms_generator/example/lib/docs/arrays/mailing_list.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/arrays/mailing_list.gform.dart
@@ -141,30 +141,34 @@ class MailingListForm implements FormModel<MailingList> {
 
   String emailListControlPath() => pathBuilder(emailListControlName);
   List<String?> get emailListValue =>
-      emailListControl.value?.whereType<String?>().toList() ?? [];
+      emailListControl?.value?.whereType<String?>().toList() ?? [];
   bool get containsEmailList => form.contains(emailListControlPath());
-  Object? get emailListErrors => emailListControl.errors;
+  Object? get emailListErrors => emailListControl?.errors;
   void get emailListFocus => form.focus(emailListControlPath());
   void emailListRemove({bool updateParent = true, bool emitEvent = true}) =>
       form.removeControl(emailListControlPath(),
           updateParent: updateParent, emitEvent: emitEvent);
   void emailListValueUpdate(List<String?> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailListControl.updateValue(value,
+      emailListControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailListValuePatch(List<String?> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailListControl.patchValue(value,
+      emailListControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailListValueReset(List<String?> value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      emailListControl.reset(
+      emailListControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormArray<String> get emailListControl =>
-      form.control(emailListControlPath()) as FormArray<String>;
+  FormArray<String>? get emailListControl {
+    if (containsEmailList) {
+      return form.control(emailListControlPath()) as FormArray<String>?;
+    }
+  }
+
   void addEmailListItem(String value,
       {List<AsyncValidatorFunction>? asyncValidators,
       List<ValidatorFunction>? validators,
@@ -187,7 +191,7 @@ class MailingListForm implements FormModel<MailingList> {
         break;
     }
 
-    emailListControl.add(FormControl<String>(
+    emailListControl?.add(FormControl<String>(
       value: value,
       validators: resultingValidators,
       asyncValidators: resultingAsyncValidators,

--- a/packages/reactive_forms_generator/example/lib/docs/arrays/mailing_list_form.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/arrays/mailing_list_form.dart
@@ -61,13 +61,14 @@ class MailingListFormWidget extends StatelessWidget {
                   };
                   final errors = <String, dynamic>{};
 
-                  formModel.emailListControl.errors.forEach((key, value) {
+                  formModel.emailListControl?.errors.forEach((key, value) {
                     final intKey = int.tryParse(key);
                     if (intKey == null) {
                       errors[key] = value;
                     }
                   });
-                  if (formModel.emailListControl.hasErrors &&
+                  if (formModel.emailListControl != null &&
+                      formModel.emailListControl!.hasErrors &&
                       errors.isNotEmpty) {
                     return Text(errorText[errors.entries.first.key] ?? '');
                   } else {

--- a/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class.gform.dart
@@ -147,15 +147,15 @@ class FreezedClassForm implements FormModel<FreezedClass> {
   String idControlPath() => pathBuilder(idControlName);
   String nameControlPath() => pathBuilder(nameControlName);
   String yearControlPath() => pathBuilder(yearControlName);
-  String? get idValue => idControl.value;
-  String? get nameValue => nameControl.value;
-  double? get yearValue => yearControl.value;
+  String? get idValue => idControl?.value;
+  String? get nameValue => nameControl?.value;
+  double? get yearValue => yearControl?.value;
   bool get containsId => form.contains(idControlPath());
   bool get containsName => form.contains(nameControlPath());
   bool get containsYear => form.contains(yearControlPath());
-  Object? get idErrors => idControl.errors;
-  Object? get nameErrors => nameControl.errors;
-  Object? get yearErrors => yearControl.errors;
+  Object? get idErrors => idControl?.errors;
+  Object? get nameErrors => nameControl?.errors;
+  Object? get yearErrors => yearControl?.errors;
   void get idFocus => form.focus(idControlPath());
   void get nameFocus => form.focus(nameControlPath());
   void get yearFocus => form.focus(yearControlPath());
@@ -170,55 +170,67 @@ class FreezedClassForm implements FormModel<FreezedClass> {
           updateParent: updateParent, emitEvent: emitEvent);
   void idValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      idControl.updateValue(value,
+      idControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void nameValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      nameControl.updateValue(value,
+      nameControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void yearValueUpdate(double? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      yearControl.updateValue(value,
+      yearControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void idValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      idControl.patchValue(value,
+      idControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void nameValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      nameControl.patchValue(value,
+      nameControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void yearValuePatch(double? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      yearControl.patchValue(value,
+      yearControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void idValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      idControl.reset(
+      idControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void nameValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      nameControl.reset(
+      nameControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void yearValueReset(double? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      yearControl.reset(
+      yearControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get idControl =>
-      form.control(idControlPath()) as FormControl<String>;
-  FormControl<String> get nameControl =>
-      form.control(nameControlPath()) as FormControl<String>;
-  FormControl<double> get yearControl =>
-      form.control(yearControlPath()) as FormControl<double>;
+  FormControl<String>? get idControl {
+    if (containsId) {
+      return form.control(idControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get nameControl {
+    if (containsName) {
+      return form.control(nameControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<double>? get yearControl {
+    if (containsYear) {
+      return form.control(yearControlPath()) as FormControl<double>?;
+    }
+  }
+
   FreezedClass get model =>
       FreezedClass(id: idValue, name: nameValue, year: yearValue);
   void updateValue(FreezedClass value,

--- a/packages/reactive_forms_generator/example/lib/docs/freezed2/test.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed2/test.gform.dart
@@ -141,12 +141,12 @@ class TestForm implements FormModel<Test> {
 
   String titleControlPath() => pathBuilder(titleControlName);
   String descriptionControlPath() => pathBuilder(descriptionControlName);
-  String get titleValue => titleControl.value as String;
-  String? get descriptionValue => descriptionControl.value;
+  String get titleValue => titleControl?.value as String;
+  String? get descriptionValue => descriptionControl?.value;
   bool get containsTitle => form.contains(titleControlPath());
   bool get containsDescription => form.contains(descriptionControlPath());
-  Object? get titleErrors => titleControl.errors;
-  Object? get descriptionErrors => descriptionControl.errors;
+  Object? get titleErrors => titleControl?.errors;
+  Object? get descriptionErrors => descriptionControl?.errors;
   void get titleFocus => form.focus(titleControlPath());
   void get descriptionFocus => form.focus(descriptionControlPath());
   void titleRemove({bool updateParent = true, bool emitEvent = true}) =>
@@ -157,38 +157,46 @@ class TestForm implements FormModel<Test> {
           updateParent: updateParent, emitEvent: emitEvent);
   void titleValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      titleControl.updateValue(value,
+      titleControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void descriptionValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      descriptionControl.updateValue(value,
+      descriptionControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void titleValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      titleControl.patchValue(value,
+      titleControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void descriptionValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      descriptionControl.patchValue(value,
+      descriptionControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void titleValueReset(String value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      titleControl.reset(
+      titleControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void descriptionValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      descriptionControl.reset(
+      descriptionControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get titleControl =>
-      form.control(titleControlPath()) as FormControl<String>;
-  FormControl<String> get descriptionControl =>
-      form.control(descriptionControlPath()) as FormControl<String>;
+  FormControl<String>? get titleControl {
+    if (containsTitle) {
+      return form.control(titleControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get descriptionControl {
+    if (containsDescription) {
+      return form.control(descriptionControlPath()) as FormControl<String>?;
+    }
+  }
+
   Test get model => Test(title: titleValue, description: descriptionValue);
   void updateValue(Test value,
           {bool updateParent = true, bool emitEvent = true}) =>

--- a/packages/reactive_forms_generator/example/lib/docs/group/user_profile.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/group/user_profile.gform.dart
@@ -156,18 +156,18 @@ class UserProfileForm implements FormModel<UserProfile> {
   String lastNameControlPath() => pathBuilder(lastNameControlName);
   String homeControlPath() => pathBuilder(homeControlName);
   String officeControlPath() => pathBuilder(officeControlName);
-  String get firstNameValue => firstNameControl.value as String;
-  String get lastNameValue => lastNameControl.value as String;
+  String get firstNameValue => firstNameControl?.value as String;
+  String get lastNameValue => lastNameControl?.value as String;
   Address? get homeValue => homeForm.model;
   Address? get officeValue => officeForm.model;
   bool get containsFirstName => form.contains(firstNameControlPath());
   bool get containsLastName => form.contains(lastNameControlPath());
   bool get containsHome => form.contains(homeControlPath());
   bool get containsOffice => form.contains(officeControlPath());
-  Object? get firstNameErrors => firstNameControl.errors;
-  Object? get lastNameErrors => lastNameControl.errors;
-  Object? get homeErrors => homeControl.errors;
-  Object? get officeErrors => officeControl.errors;
+  Object? get firstNameErrors => firstNameControl?.errors;
+  Object? get lastNameErrors => lastNameControl?.errors;
+  Object? get homeErrors => homeControl?.errors;
+  Object? get officeErrors => officeControl?.errors;
   void get firstNameFocus => form.focus(firstNameControlPath());
   void get lastNameFocus => form.focus(lastNameControlPath());
   void get homeFocus => form.focus(homeControlPath());
@@ -186,41 +186,41 @@ class UserProfileForm implements FormModel<UserProfile> {
           updateParent: updateParent, emitEvent: emitEvent);
   void firstNameValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      firstNameControl.updateValue(value,
+      firstNameControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void lastNameValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      lastNameControl.updateValue(value,
+      lastNameControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void homeValueUpdate(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      homeControl.updateValue(
+      homeControl?.updateValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void officeValueUpdate(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      officeControl.updateValue(
+      officeControl?.updateValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void firstNameValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      firstNameControl.patchValue(value,
+      firstNameControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void lastNameValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      lastNameControl.patchValue(value,
+      lastNameControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void homeValuePatch(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      homeControl.patchValue(
+      homeControl?.patchValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void officeValuePatch(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      officeControl.patchValue(
+      officeControl?.patchValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
@@ -229,21 +229,21 @@ class UserProfileForm implements FormModel<UserProfile> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      firstNameControl.reset(
+      firstNameControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void lastNameValueReset(String value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      lastNameControl.reset(
+      lastNameControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void homeValueReset(Address? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      homeControl.reset(
+      homeControl?.reset(
           value:
               AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
@@ -253,17 +253,35 @@ class UserProfileForm implements FormModel<UserProfile> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      officeControl.reset(
+      officeControl?.reset(
           value:
               AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
-  FormControl<String> get firstNameControl =>
-      form.control(firstNameControlPath()) as FormControl<String>;
-  FormControl<String> get lastNameControl =>
-      form.control(lastNameControlPath()) as FormControl<String>;
-  FormGroup get homeControl => form.control(homeControlPath()) as FormGroup;
-  FormGroup get officeControl => form.control(officeControlPath()) as FormGroup;
+  FormControl<String>? get firstNameControl {
+    if (containsFirstName) {
+      return form.control(firstNameControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get lastNameControl {
+    if (containsLastName) {
+      return form.control(lastNameControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormGroup? get homeControl {
+    if (containsHome) {
+      return form.control(homeControlPath()) as FormGroup?;
+    }
+  }
+
+  FormGroup? get officeControl {
+    if (containsOffice) {
+      return form.control(officeControlPath()) as FormGroup?;
+    }
+  }
+
   UserProfile get model => UserProfile(
       firstName: firstNameValue,
       lastName: lastNameValue,
@@ -331,15 +349,15 @@ class AddressForm implements FormModel<Address> {
   String streetControlPath() => pathBuilder(streetControlName);
   String cityControlPath() => pathBuilder(cityControlName);
   String zipControlPath() => pathBuilder(zipControlName);
-  String? get streetValue => streetControl.value;
-  String? get cityValue => cityControl.value;
-  String? get zipValue => zipControl.value;
+  String? get streetValue => streetControl?.value;
+  String? get cityValue => cityControl?.value;
+  String? get zipValue => zipControl?.value;
   bool get containsStreet => form.contains(streetControlPath());
   bool get containsCity => form.contains(cityControlPath());
   bool get containsZip => form.contains(zipControlPath());
-  Object? get streetErrors => streetControl.errors;
-  Object? get cityErrors => cityControl.errors;
-  Object? get zipErrors => zipControl.errors;
+  Object? get streetErrors => streetControl?.errors;
+  Object? get cityErrors => cityControl?.errors;
+  Object? get zipErrors => zipControl?.errors;
   void get streetFocus => form.focus(streetControlPath());
   void get cityFocus => form.focus(cityControlPath());
   void get zipFocus => form.focus(zipControlPath());
@@ -354,55 +372,67 @@ class AddressForm implements FormModel<Address> {
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      streetControl.updateValue(value,
+      streetControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void cityValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      cityControl.updateValue(value,
+      cityControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void zipValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      zipControl.updateValue(value,
+      zipControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      streetControl.patchValue(value,
+      streetControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void cityValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      cityControl.patchValue(value,
+      cityControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void zipValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      zipControl.patchValue(value,
+      zipControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      streetControl.reset(
+      streetControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void cityValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      cityControl.reset(
+      cityControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void zipValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      zipControl.reset(
+      zipControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get streetControl =>
-      form.control(streetControlPath()) as FormControl<String>;
-  FormControl<String> get cityControl =>
-      form.control(cityControlPath()) as FormControl<String>;
-  FormControl<String> get zipControl =>
-      form.control(zipControlPath()) as FormControl<String>;
+  FormControl<String>? get streetControl {
+    if (containsStreet) {
+      return form.control(streetControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get cityControl {
+    if (containsCity) {
+      return form.control(cityControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get zipControl {
+    if (containsZip) {
+      return form.control(zipControlPath()) as FormControl<String>?;
+    }
+  }
+
   Address get model =>
       Address(street: streetValue, city: cityValue, zip: zipValue);
   void updateValue(Address? value,

--- a/packages/reactive_forms_generator/example/lib/docs/remove_form_control/tiny.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/remove_form_control/tiny.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:example/helpers.dart';
+import 'package:reactive_forms_annotations/reactive_forms_annotations.dart';
+
+part 'tiny.gform.dart';
+
+@ReactiveFormAnnotation()
+class Tiny {
+  final String email;
+
+  // If you might delete a field in a form widget,
+  // you'll have to make it optional
+  final String? password;
+
+  Tiny({
+    @FormControlAnnotation(
+      validators: const [requiredValidator],
+    )
+        this.email = '',
+    @FormControlAnnotation(
+      validators: const [requiredValidator],
+    )
+        this.password = '',
+  });
+}

--- a/packages/reactive_forms_generator/example/lib/docs/remove_form_control/tiny.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/remove_form_control/tiny.gform.dart
@@ -142,7 +142,7 @@ class TinyForm implements FormModel<Tiny> {
   String emailControlPath() => pathBuilder(emailControlName);
   String passwordControlPath() => pathBuilder(passwordControlName);
   String get emailValue => emailControl?.value as String;
-  String get passwordValue => passwordControl?.value as String;
+  String? get passwordValue => passwordControl?.value;
   bool get containsEmail => form.contains(emailControlPath());
   bool get containsPassword => form.contains(passwordControlPath());
   Object? get emailErrors => emailControl?.errors;
@@ -159,7 +159,7 @@ class TinyForm implements FormModel<Tiny> {
           {bool updateParent = true, bool emitEvent = true}) =>
       emailControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
-  void passwordValueUpdate(String value,
+  void passwordValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
       passwordControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
@@ -167,7 +167,7 @@ class TinyForm implements FormModel<Tiny> {
           {bool updateParent = true, bool emitEvent = true}) =>
       emailControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
-  void passwordValuePatch(String value,
+  void passwordValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
       passwordControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
@@ -178,7 +178,7 @@ class TinyForm implements FormModel<Tiny> {
           bool? disabled}) =>
       emailControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  void passwordValueReset(String value,
+  void passwordValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,

--- a/packages/reactive_forms_generator/example/lib/docs/remove_form_control/tiny_form.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/remove_form_control/tiny_form.dart
@@ -1,0 +1,54 @@
+import 'package:example/docs/remove_form_control/tiny.dart';
+import 'package:example/sample_screen.dart';
+import 'package:flutter/material.dart' hide ProgressIndicator;
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:reactive_forms_annotations/reactive_forms_annotations.dart';
+
+class SuperTinyFormWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SampleScreen(
+      title: Text('Super Tiny'),
+      body: TinyFormBuilder(
+        model: Tiny(),
+        builder: (context, formModel, child) {
+          // We don't want the password control but we still want to use the
+          // TinyForm for code reuse purposes
+          formModel.passwordRemove();
+          return Column(
+            children: [
+              ReactiveTextField<String>(
+                formControl: formModel.emailControl,
+                validationMessages: (control) => {
+                  ValidationMessage.required: 'The email must not be empty',
+                },
+                decoration: const InputDecoration(
+                  labelText: 'Email',
+                  helperText: '',
+                  helperStyle: TextStyle(height: 0.7),
+                  errorStyle: TextStyle(height: 0.7),
+                ),
+              ),
+              const SizedBox(height: 8.0),
+              ReactiveTinyFormConsumer(
+                builder: (context, formModel, child) {
+                  return ElevatedButton(
+                    child: Text('Submit'),
+                    onPressed: formModel.form.valid
+                        ? () {
+                            // ignore: unnecessary_cast
+                            print((formModel as FormModel<Tiny>).model);
+                            print(formModel.model.email);
+                            print(formModel.model.password);
+                          }
+                        : null,
+                  );
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/packages/reactive_forms_generator/example/lib/drawer.dart
+++ b/packages/reactive_forms_generator/example/lib/drawer.dart
@@ -69,6 +69,12 @@ class AppDrawer extends StatelessWidget {
                 Routes.freezed,
               ),
             ),
+            ListTile(
+              title: const Text('Super Tiny form'),
+              onTap: () => Navigator.of(context).pushReplacementNamed(
+                Routes.superTiny,
+              ),
+            ),
           ],
         ),
       ),

--- a/packages/reactive_forms_generator/example/lib/forms/array.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/forms/array.gform.dart
@@ -150,21 +150,21 @@ class ArrayNullableForm implements FormModel<ArrayNullable> {
   String emailListControlPath() => pathBuilder(emailListControlName);
   String fruitListControlPath() => pathBuilder(fruitListControlName);
   String vegetablesListControlPath() => pathBuilder(vegetablesListControlName);
-  List<String?>? get someListValue => someListControl.value;
+  List<String?>? get someListValue => someListControl?.value;
   List<String> get emailListValue =>
-      emailListControl.value?.whereType<String>().toList() ?? [];
+      emailListControl?.value?.whereType<String>().toList() ?? [];
   List<bool?> get fruitListValue =>
-      fruitListControl.value?.whereType<bool?>().toList() ?? [];
+      fruitListControl?.value?.whereType<bool?>().toList() ?? [];
   List<String?>? get vegetablesListValue =>
-      vegetablesListControl.value?.whereType<String?>().toList() ?? [];
+      vegetablesListControl?.value?.whereType<String?>().toList() ?? [];
   bool get containsSomeList => form.contains(someListControlPath());
   bool get containsEmailList => form.contains(emailListControlPath());
   bool get containsFruitList => form.contains(fruitListControlPath());
   bool get containsVegetablesList => form.contains(vegetablesListControlPath());
-  Object? get someListErrors => someListControl.errors;
-  Object? get emailListErrors => emailListControl.errors;
-  Object? get fruitListErrors => fruitListControl.errors;
-  Object? get vegetablesListErrors => vegetablesListControl.errors;
+  Object? get someListErrors => someListControl?.errors;
+  Object? get emailListErrors => emailListControl?.errors;
+  Object? get fruitListErrors => fruitListControl?.errors;
+  Object? get vegetablesListErrors => vegetablesListControl?.errors;
   void get someListFocus => form.focus(someListControlPath());
   void get emailListFocus => form.focus(emailListControlPath());
   void get fruitListFocus => form.focus(fruitListControlPath());
@@ -184,72 +184,88 @@ class ArrayNullableForm implements FormModel<ArrayNullable> {
           updateParent: updateParent, emitEvent: emitEvent);
   void someListValueUpdate(List<String?>? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      someListControl.updateValue(value,
+      someListControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailListValueUpdate(List<String> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailListControl.updateValue(value,
+      emailListControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void fruitListValueUpdate(List<bool?> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      fruitListControl.updateValue(value,
+      fruitListControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void vegetablesListValueUpdate(List<String?>? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      vegetablesListControl.updateValue(value,
+      vegetablesListControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void someListValuePatch(List<String?>? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      someListControl.patchValue(value,
+      someListControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailListValuePatch(List<String> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailListControl.patchValue(value,
+      emailListControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void fruitListValuePatch(List<bool?> value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      fruitListControl.patchValue(value,
+      fruitListControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void vegetablesListValuePatch(List<String?>? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      vegetablesListControl.patchValue(value,
+      vegetablesListControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void someListValueReset(List<String?>? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      someListControl.reset(
+      someListControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void emailListValueReset(List<String> value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      emailListControl.reset(
+      emailListControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void fruitListValueReset(List<bool?> value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      fruitListControl.reset(
+      fruitListControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void vegetablesListValueReset(List<String?>? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      vegetablesListControl.reset(
+      vegetablesListControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<List<String?>> get someListControl =>
-      form.control(someListControlPath()) as FormControl<List<String?>>;
-  FormArray<String> get emailListControl =>
-      form.control(emailListControlPath()) as FormArray<String>;
-  FormArray<bool> get fruitListControl =>
-      form.control(fruitListControlPath()) as FormArray<bool>;
-  FormArray<String> get vegetablesListControl =>
-      form.control(vegetablesListControlPath()) as FormArray<String>;
+  FormControl<List<String?>>? get someListControl {
+    if (containsSomeList) {
+      return form.control(someListControlPath()) as FormControl<List<String?>>?;
+    }
+  }
+
+  FormArray<String>? get emailListControl {
+    if (containsEmailList) {
+      return form.control(emailListControlPath()) as FormArray<String>?;
+    }
+  }
+
+  FormArray<bool>? get fruitListControl {
+    if (containsFruitList) {
+      return form.control(fruitListControlPath()) as FormArray<bool>?;
+    }
+  }
+
+  FormArray<String>? get vegetablesListControl {
+    if (containsVegetablesList) {
+      return form.control(vegetablesListControlPath()) as FormArray<String>?;
+    }
+  }
+
   void addEmailListItem(String value,
       {List<AsyncValidatorFunction>? asyncValidators,
       List<ValidatorFunction>? validators,
@@ -272,7 +288,7 @@ class ArrayNullableForm implements FormModel<ArrayNullable> {
         break;
     }
 
-    emailListControl.add(FormControl<String>(
+    emailListControl?.add(FormControl<String>(
       value: value,
       validators: resultingValidators,
       asyncValidators: resultingAsyncValidators,
@@ -303,7 +319,7 @@ class ArrayNullableForm implements FormModel<ArrayNullable> {
         break;
     }
 
-    fruitListControl.add(FormControl<bool>(
+    fruitListControl?.add(FormControl<bool>(
       value: value,
       validators: resultingValidators,
       asyncValidators: resultingAsyncValidators,
@@ -334,7 +350,7 @@ class ArrayNullableForm implements FormModel<ArrayNullable> {
         break;
     }
 
-    vegetablesListControl.add(FormControl<String>(
+    vegetablesListControl?.add(FormControl<String>(
       value: value,
       validators: resultingValidators,
       asyncValidators: resultingAsyncValidators,

--- a/packages/reactive_forms_generator/example/lib/forms/groups_form.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/forms/groups_form.gform.dart
@@ -168,10 +168,10 @@ class GroupForm implements FormModel<Group> {
   bool get containsPhone => form.contains(phoneControlPath());
   bool get containsAddress => form.contains(addressControlPath());
   bool get containsAddress2 => form.contains(address2ControlPath());
-  Object? get personalErrors => personalControl.errors;
-  Object? get phoneErrors => phoneControl.errors;
-  Object? get addressErrors => addressControl.errors;
-  Object? get address2Errors => address2Control.errors;
+  Object? get personalErrors => personalControl?.errors;
+  Object? get phoneErrors => phoneControl?.errors;
+  Object? get addressErrors => addressControl?.errors;
+  Object? get address2Errors => address2Control?.errors;
   void get personalFocus => form.focus(personalControlPath());
   void get phoneFocus => form.focus(phoneControlPath());
   void get addressFocus => form.focus(addressControlPath());
@@ -190,49 +190,49 @@ class GroupForm implements FormModel<Group> {
           updateParent: updateParent, emitEvent: emitEvent);
   void personalValueUpdate(Personal? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      personalControl.updateValue(
+      personalControl?.updateValue(
           PersonalForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void phoneValueUpdate(Phone? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      phoneControl.updateValue(
+      phoneControl?.updateValue(
           PhoneForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void addressValueUpdate(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      addressControl.updateValue(
+      addressControl?.updateValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void address2ValueUpdate(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      address2Control.updateValue(
+      address2Control?.updateValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void personalValuePatch(Personal? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      personalControl.patchValue(
+      personalControl?.patchValue(
           PersonalForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void phoneValuePatch(Phone? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      phoneControl.patchValue(
+      phoneControl?.patchValue(
           PhoneForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void addressValuePatch(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      addressControl.patchValue(
+      addressControl?.patchValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
   void address2ValuePatch(Address? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      address2Control.patchValue(
+      address2Control?.patchValue(
           AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
@@ -241,7 +241,7 @@ class GroupForm implements FormModel<Group> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      personalControl.reset(
+      personalControl?.reset(
           value:
               PersonalForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
@@ -251,7 +251,7 @@ class GroupForm implements FormModel<Group> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      phoneControl.reset(
+      phoneControl?.reset(
           value: PhoneForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
@@ -260,7 +260,7 @@ class GroupForm implements FormModel<Group> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      addressControl.reset(
+      addressControl?.reset(
           value:
               AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
@@ -270,18 +270,35 @@ class GroupForm implements FormModel<Group> {
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      address2Control.reset(
+      address2Control?.reset(
           value:
               AddressForm(value, FormGroup({}), null).formElements().rawValue,
           updateParent: updateParent,
           emitEvent: emitEvent);
-  FormGroup get personalControl =>
-      form.control(personalControlPath()) as FormGroup;
-  FormGroup get phoneControl => form.control(phoneControlPath()) as FormGroup;
-  FormGroup get addressControl =>
-      form.control(addressControlPath()) as FormGroup;
-  FormGroup get address2Control =>
-      form.control(address2ControlPath()) as FormGroup;
+  FormGroup? get personalControl {
+    if (containsPersonal) {
+      return form.control(personalControlPath()) as FormGroup?;
+    }
+  }
+
+  FormGroup? get phoneControl {
+    if (containsPhone) {
+      return form.control(phoneControlPath()) as FormGroup?;
+    }
+  }
+
+  FormGroup? get addressControl {
+    if (containsAddress) {
+      return form.control(addressControlPath()) as FormGroup?;
+    }
+  }
+
+  FormGroup? get address2Control {
+    if (containsAddress2) {
+      return form.control(address2ControlPath()) as FormGroup?;
+    }
+  }
+
   Group get model => Group(
       personal: personalValue,
       phone: phoneValue,
@@ -332,12 +349,12 @@ class PersonalForm implements FormModel<Personal> {
 
   String nameControlPath() => pathBuilder(nameControlName);
   String emailControlPath() => pathBuilder(emailControlName);
-  String? get nameValue => nameControl.value;
-  String? get emailValue => emailControl.value;
+  String? get nameValue => nameControl?.value;
+  String? get emailValue => emailControl?.value;
   bool get containsName => form.contains(nameControlPath());
   bool get containsEmail => form.contains(emailControlPath());
-  Object? get nameErrors => nameControl.errors;
-  Object? get emailErrors => emailControl.errors;
+  Object? get nameErrors => nameControl?.errors;
+  Object? get emailErrors => emailControl?.errors;
   void get nameFocus => form.focus(nameControlPath());
   void get emailFocus => form.focus(emailControlPath());
   void nameRemove({bool updateParent = true, bool emitEvent = true}) =>
@@ -348,38 +365,46 @@ class PersonalForm implements FormModel<Personal> {
           updateParent: updateParent, emitEvent: emitEvent);
   void nameValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      nameControl.updateValue(value,
+      nameControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailControl.updateValue(value,
+      emailControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void nameValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      nameControl.patchValue(value,
+      nameControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailControl.patchValue(value,
+      emailControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void nameValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      nameControl.reset(
+      nameControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void emailValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      emailControl.reset(
+      emailControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get nameControl =>
-      form.control(nameControlPath()) as FormControl<String>;
-  FormControl<String> get emailControl =>
-      form.control(emailControlPath()) as FormControl<String>;
+  FormControl<String>? get nameControl {
+    if (containsName) {
+      return form.control(nameControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get emailControl {
+    if (containsEmail) {
+      return form.control(emailControlPath()) as FormControl<String>?;
+    }
+  }
+
   Personal get model => Personal(name: nameValue, email: emailValue);
   void updateValue(Personal? value,
           {bool updateParent = true, bool emitEvent = true}) =>
@@ -437,12 +462,12 @@ class PhoneForm implements FormModel<Phone> {
 
   String phoneNumberControlPath() => pathBuilder(phoneNumberControlName);
   String countryIsoControlPath() => pathBuilder(countryIsoControlName);
-  String? get phoneNumberValue => phoneNumberControl.value;
-  String? get countryIsoValue => countryIsoControl.value;
+  String? get phoneNumberValue => phoneNumberControl?.value;
+  String? get countryIsoValue => countryIsoControl?.value;
   bool get containsPhoneNumber => form.contains(phoneNumberControlPath());
   bool get containsCountryIso => form.contains(countryIsoControlPath());
-  Object? get phoneNumberErrors => phoneNumberControl.errors;
-  Object? get countryIsoErrors => countryIsoControl.errors;
+  Object? get phoneNumberErrors => phoneNumberControl?.errors;
+  Object? get countryIsoErrors => countryIsoControl?.errors;
   void get phoneNumberFocus => form.focus(phoneNumberControlPath());
   void get countryIsoFocus => form.focus(countryIsoControlPath());
   void phoneNumberRemove({bool updateParent = true, bool emitEvent = true}) =>
@@ -453,38 +478,46 @@ class PhoneForm implements FormModel<Phone> {
           updateParent: updateParent, emitEvent: emitEvent);
   void phoneNumberValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      phoneNumberControl.updateValue(value,
+      phoneNumberControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void countryIsoValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      countryIsoControl.updateValue(value,
+      countryIsoControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void phoneNumberValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      phoneNumberControl.patchValue(value,
+      phoneNumberControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void countryIsoValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      countryIsoControl.patchValue(value,
+      countryIsoControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void phoneNumberValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      phoneNumberControl.reset(
+      phoneNumberControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void countryIsoValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      countryIsoControl.reset(
+      countryIsoControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get phoneNumberControl =>
-      form.control(phoneNumberControlPath()) as FormControl<String>;
-  FormControl<String> get countryIsoControl =>
-      form.control(countryIsoControlPath()) as FormControl<String>;
+  FormControl<String>? get phoneNumberControl {
+    if (containsPhoneNumber) {
+      return form.control(phoneNumberControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get countryIsoControl {
+    if (containsCountryIso) {
+      return form.control(countryIsoControlPath()) as FormControl<String>?;
+    }
+  }
+
   Phone get model =>
       Phone(phoneNumber: phoneNumberValue, countryIso: countryIsoValue);
   void updateValue(Phone? value,
@@ -545,15 +578,15 @@ class AddressForm implements FormModel<Address> {
   String streetControlPath() => pathBuilder(streetControlName);
   String cityControlPath() => pathBuilder(cityControlName);
   String zipControlPath() => pathBuilder(zipControlName);
-  String? get streetValue => streetControl.value;
-  String? get cityValue => cityControl.value;
-  String? get zipValue => zipControl.value;
+  String? get streetValue => streetControl?.value;
+  String? get cityValue => cityControl?.value;
+  String? get zipValue => zipControl?.value;
   bool get containsStreet => form.contains(streetControlPath());
   bool get containsCity => form.contains(cityControlPath());
   bool get containsZip => form.contains(zipControlPath());
-  Object? get streetErrors => streetControl.errors;
-  Object? get cityErrors => cityControl.errors;
-  Object? get zipErrors => zipControl.errors;
+  Object? get streetErrors => streetControl?.errors;
+  Object? get cityErrors => cityControl?.errors;
+  Object? get zipErrors => zipControl?.errors;
   void get streetFocus => form.focus(streetControlPath());
   void get cityFocus => form.focus(cityControlPath());
   void get zipFocus => form.focus(zipControlPath());
@@ -568,55 +601,67 @@ class AddressForm implements FormModel<Address> {
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      streetControl.updateValue(value,
+      streetControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void cityValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      cityControl.updateValue(value,
+      cityControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void zipValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      zipControl.updateValue(value,
+      zipControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      streetControl.patchValue(value,
+      streetControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void cityValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      cityControl.patchValue(value,
+      cityControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void zipValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      zipControl.patchValue(value,
+      zipControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void streetValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      streetControl.reset(
+      streetControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void cityValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      cityControl.reset(
+      cityControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void zipValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      zipControl.reset(
+      zipControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get streetControl =>
-      form.control(streetControlPath()) as FormControl<String>;
-  FormControl<String> get cityControl =>
-      form.control(cityControlPath()) as FormControl<String>;
-  FormControl<String> get zipControl =>
-      form.control(zipControlPath()) as FormControl<String>;
+  FormControl<String>? get streetControl {
+    if (containsStreet) {
+      return form.control(streetControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get cityControl {
+    if (containsCity) {
+      return form.control(cityControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get zipControl {
+    if (containsZip) {
+      return form.control(zipControlPath()) as FormControl<String>?;
+    }
+  }
+
   Address get model =>
       Address(street: streetValue, city: cityValue, zip: zipValue);
   void updateValue(Address? value,

--- a/packages/reactive_forms_generator/example/lib/forms/login.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/forms/login.gform.dart
@@ -156,13 +156,13 @@ class LoginForm implements FormModel<Login> {
   String modeControlPath() => pathBuilder(modeControlName);
   String timeoutControlPath() => pathBuilder(timeoutControlName);
   String heightControlPath() => pathBuilder(heightControlName);
-  String get emailValue => emailControl.value as String;
-  String get passwordValue => passwordControl.value as String;
-  bool get rememberMeValue => rememberMeControl.value as bool;
-  String get themeValue => themeControl.value as String;
-  UserMode get modeValue => modeControl.value as UserMode;
-  int get timeoutValue => timeoutControl.value as int;
-  double get heightValue => heightControl.value as double;
+  String get emailValue => emailControl?.value as String;
+  String get passwordValue => passwordControl?.value as String;
+  bool get rememberMeValue => rememberMeControl?.value as bool;
+  String get themeValue => themeControl?.value as String;
+  UserMode get modeValue => modeControl?.value as UserMode;
+  int get timeoutValue => timeoutControl?.value as int;
+  double get heightValue => heightControl?.value as double;
   bool get containsEmail => form.contains(emailControlPath());
   bool get containsPassword => form.contains(passwordControlPath());
   bool get containsRememberMe => form.contains(rememberMeControlPath());
@@ -170,13 +170,13 @@ class LoginForm implements FormModel<Login> {
   bool get containsMode => form.contains(modeControlPath());
   bool get containsTimeout => form.contains(timeoutControlPath());
   bool get containsHeight => form.contains(heightControlPath());
-  Object? get emailErrors => emailControl.errors;
-  Object? get passwordErrors => passwordControl.errors;
-  Object? get rememberMeErrors => rememberMeControl.errors;
-  Object? get themeErrors => themeControl.errors;
-  Object? get modeErrors => modeControl.errors;
-  Object? get timeoutErrors => timeoutControl.errors;
-  Object? get heightErrors => heightControl.errors;
+  Object? get emailErrors => emailControl?.errors;
+  Object? get passwordErrors => passwordControl?.errors;
+  Object? get rememberMeErrors => rememberMeControl?.errors;
+  Object? get themeErrors => themeControl?.errors;
+  Object? get modeErrors => modeControl?.errors;
+  Object? get timeoutErrors => timeoutControl?.errors;
+  Object? get heightErrors => heightControl?.errors;
   void get emailFocus => form.focus(emailControlPath());
   void get passwordFocus => form.focus(passwordControlPath());
   void get rememberMeFocus => form.focus(rememberMeControlPath());
@@ -207,123 +207,151 @@ class LoginForm implements FormModel<Login> {
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailControl.updateValue(value,
+      emailControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void passwordValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      passwordControl.updateValue(value,
+      passwordControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void rememberMeValueUpdate(bool value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      rememberMeControl.updateValue(value,
+      rememberMeControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void themeValueUpdate(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      themeControl.updateValue(value,
+      themeControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void modeValueUpdate(UserMode value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      modeControl.updateValue(value,
+      modeControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void timeoutValueUpdate(int value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      timeoutControl.updateValue(value,
+      timeoutControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void heightValueUpdate(double value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      heightControl.updateValue(value,
+      heightControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailControl.patchValue(value,
+      emailControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void passwordValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      passwordControl.patchValue(value,
+      passwordControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void rememberMeValuePatch(bool value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      rememberMeControl.patchValue(value,
+      rememberMeControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void themeValuePatch(String value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      themeControl.patchValue(value,
+      themeControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void modeValuePatch(UserMode value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      modeControl.patchValue(value,
+      modeControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void timeoutValuePatch(int value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      timeoutControl.patchValue(value,
+      timeoutControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void heightValuePatch(double value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      heightControl.patchValue(value,
+      heightControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValueReset(String value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      emailControl.reset(
+      emailControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void passwordValueReset(String value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      passwordControl.reset(
+      passwordControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void rememberMeValueReset(bool value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      rememberMeControl.reset(
+      rememberMeControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void themeValueReset(String value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      themeControl.reset(
+      themeControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void modeValueReset(UserMode value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      modeControl.reset(
+      modeControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void timeoutValueReset(int value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      timeoutControl.reset(
+      timeoutControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void heightValueReset(double value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      heightControl.reset(
+      heightControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get emailControl =>
-      form.control(emailControlPath()) as FormControl<String>;
-  FormControl<String> get passwordControl =>
-      form.control(passwordControlPath()) as FormControl<String>;
-  FormControl<bool> get rememberMeControl =>
-      form.control(rememberMeControlPath()) as FormControl<bool>;
-  FormControl<String> get themeControl =>
-      form.control(themeControlPath()) as FormControl<String>;
-  FormControl<UserMode> get modeControl =>
-      form.control(modeControlPath()) as FormControl<UserMode>;
-  FormControl<int> get timeoutControl =>
-      form.control(timeoutControlPath()) as FormControl<int>;
-  FormControl<double> get heightControl =>
-      form.control(heightControlPath()) as FormControl<double>;
+  FormControl<String>? get emailControl {
+    if (containsEmail) {
+      return form.control(emailControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get passwordControl {
+    if (containsPassword) {
+      return form.control(passwordControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<bool>? get rememberMeControl {
+    if (containsRememberMe) {
+      return form.control(rememberMeControlPath()) as FormControl<bool>?;
+    }
+  }
+
+  FormControl<String>? get themeControl {
+    if (containsTheme) {
+      return form.control(themeControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<UserMode>? get modeControl {
+    if (containsMode) {
+      return form.control(modeControlPath()) as FormControl<UserMode>?;
+    }
+  }
+
+  FormControl<int>? get timeoutControl {
+    if (containsTimeout) {
+      return form.control(timeoutControlPath()) as FormControl<int>?;
+    }
+  }
+
+  FormControl<double>? get heightControl {
+    if (containsHeight) {
+      return form.control(heightControlPath()) as FormControl<double>?;
+    }
+  }
+
   Login get model => Login(
       email: emailValue,
       password: passwordValue,

--- a/packages/reactive_forms_generator/example/lib/forms/login_nullable.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/forms/login_nullable.gform.dart
@@ -159,13 +159,13 @@ class LoginNullableForm implements FormModel<LoginNullable> {
   String modeControlPath() => pathBuilder(modeControlName);
   String timeoutControlPath() => pathBuilder(timeoutControlName);
   String heightControlPath() => pathBuilder(heightControlName);
-  String? get emailValue => emailControl.value;
-  String? get passwordValue => passwordControl.value;
-  bool? get rememberMeValue => rememberMeControl.value;
-  String? get themeValue => themeControl.value;
-  UserMode? get modeValue => modeControl.value;
-  int? get timeoutValue => timeoutControl.value;
-  double? get heightValue => heightControl.value;
+  String? get emailValue => emailControl?.value;
+  String? get passwordValue => passwordControl?.value;
+  bool? get rememberMeValue => rememberMeControl?.value;
+  String? get themeValue => themeControl?.value;
+  UserMode? get modeValue => modeControl?.value;
+  int? get timeoutValue => timeoutControl?.value;
+  double? get heightValue => heightControl?.value;
   bool get containsEmail => form.contains(emailControlPath());
   bool get containsPassword => form.contains(passwordControlPath());
   bool get containsRememberMe => form.contains(rememberMeControlPath());
@@ -173,13 +173,13 @@ class LoginNullableForm implements FormModel<LoginNullable> {
   bool get containsMode => form.contains(modeControlPath());
   bool get containsTimeout => form.contains(timeoutControlPath());
   bool get containsHeight => form.contains(heightControlPath());
-  Object? get emailErrors => emailControl.errors;
-  Object? get passwordErrors => passwordControl.errors;
-  Object? get rememberMeErrors => rememberMeControl.errors;
-  Object? get themeErrors => themeControl.errors;
-  Object? get modeErrors => modeControl.errors;
-  Object? get timeoutErrors => timeoutControl.errors;
-  Object? get heightErrors => heightControl.errors;
+  Object? get emailErrors => emailControl?.errors;
+  Object? get passwordErrors => passwordControl?.errors;
+  Object? get rememberMeErrors => rememberMeControl?.errors;
+  Object? get themeErrors => themeControl?.errors;
+  Object? get modeErrors => modeControl?.errors;
+  Object? get timeoutErrors => timeoutControl?.errors;
+  Object? get heightErrors => heightControl?.errors;
   void get emailFocus => form.focus(emailControlPath());
   void get passwordFocus => form.focus(passwordControlPath());
   void get rememberMeFocus => form.focus(rememberMeControlPath());
@@ -210,123 +210,151 @@ class LoginNullableForm implements FormModel<LoginNullable> {
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailControl.updateValue(value,
+      emailControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void passwordValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      passwordControl.updateValue(value,
+      passwordControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void rememberMeValueUpdate(bool? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      rememberMeControl.updateValue(value,
+      rememberMeControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void themeValueUpdate(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      themeControl.updateValue(value,
+      themeControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void modeValueUpdate(UserMode? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      modeControl.updateValue(value,
+      modeControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void timeoutValueUpdate(int? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      timeoutControl.updateValue(value,
+      timeoutControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void heightValueUpdate(double? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      heightControl.updateValue(value,
+      heightControl?.updateValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      emailControl.patchValue(value,
+      emailControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void passwordValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      passwordControl.patchValue(value,
+      passwordControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void rememberMeValuePatch(bool? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      rememberMeControl.patchValue(value,
+      rememberMeControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void themeValuePatch(String? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      themeControl.patchValue(value,
+      themeControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void modeValuePatch(UserMode? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      modeControl.patchValue(value,
+      modeControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void timeoutValuePatch(int? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      timeoutControl.patchValue(value,
+      timeoutControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void heightValuePatch(double? value,
           {bool updateParent = true, bool emitEvent = true}) =>
-      heightControl.patchValue(value,
+      heightControl?.patchValue(value,
           updateParent: updateParent, emitEvent: emitEvent);
   void emailValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      emailControl.reset(
+      emailControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void passwordValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      passwordControl.reset(
+      passwordControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void rememberMeValueReset(bool? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      rememberMeControl.reset(
+      rememberMeControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void themeValueReset(String? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      themeControl.reset(
+      themeControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void modeValueReset(UserMode? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      modeControl.reset(
+      modeControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void timeoutValueReset(int? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      timeoutControl.reset(
+      timeoutControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
   void heightValueReset(double? value,
           {bool updateParent = true,
           bool emitEvent = true,
           bool removeFocus = false,
           bool? disabled}) =>
-      heightControl.reset(
+      heightControl?.reset(
           value: value, updateParent: updateParent, emitEvent: emitEvent);
-  FormControl<String> get emailControl =>
-      form.control(emailControlPath()) as FormControl<String>;
-  FormControl<String> get passwordControl =>
-      form.control(passwordControlPath()) as FormControl<String>;
-  FormControl<bool> get rememberMeControl =>
-      form.control(rememberMeControlPath()) as FormControl<bool>;
-  FormControl<String> get themeControl =>
-      form.control(themeControlPath()) as FormControl<String>;
-  FormControl<UserMode> get modeControl =>
-      form.control(modeControlPath()) as FormControl<UserMode>;
-  FormControl<int> get timeoutControl =>
-      form.control(timeoutControlPath()) as FormControl<int>;
-  FormControl<double> get heightControl =>
-      form.control(heightControlPath()) as FormControl<double>;
+  FormControl<String>? get emailControl {
+    if (containsEmail) {
+      return form.control(emailControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<String>? get passwordControl {
+    if (containsPassword) {
+      return form.control(passwordControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<bool>? get rememberMeControl {
+    if (containsRememberMe) {
+      return form.control(rememberMeControlPath()) as FormControl<bool>?;
+    }
+  }
+
+  FormControl<String>? get themeControl {
+    if (containsTheme) {
+      return form.control(themeControlPath()) as FormControl<String>?;
+    }
+  }
+
+  FormControl<UserMode>? get modeControl {
+    if (containsMode) {
+      return form.control(modeControlPath()) as FormControl<UserMode>?;
+    }
+  }
+
+  FormControl<int>? get timeoutControl {
+    if (containsTimeout) {
+      return form.control(timeoutControlPath()) as FormControl<int>?;
+    }
+  }
+
+  FormControl<double>? get heightControl {
+    if (containsHeight) {
+      return form.control(heightControlPath()) as FormControl<double>?;
+    }
+  }
+
   LoginNullable get model => LoginNullable(
       email: emailValue,
       password: passwordValue,

--- a/packages/reactive_forms_generator/example/lib/main.dart
+++ b/packages/reactive_forms_generator/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:example/docs/array_group/delivery_route_form.dart';
 import 'package:example/docs/arrays/mailing_list_form.dart';
 import 'package:example/docs/freezed/freezed_form.dart';
 import 'package:example/docs/group/user_profile_form.dart';
+import 'package:example/docs/remove_form_control/tiny_form.dart';
 import 'package:example/routes/array_nullable_form.dart';
 import 'package:example/routes/group_nullable_group.dart';
 import 'package:example/routes/login_form.dart';
@@ -34,6 +35,8 @@ class Routes {
   static const arrayNullable = '/array-nullable';
 
   static const freezed = '/freezed';
+
+  static const superTiny = '/super-tiny';
 }
 
 class MyApp extends StatelessWidget {
@@ -56,6 +59,7 @@ class MyApp extends StatelessWidget {
         Routes.deliveryList: (_) => DeliveryListFormWidget(),
         Routes.deliveryPoint: (_) => DeliveryPointWidget(),
         Routes.freezed: (_) => FreezedFormWidget(),
+        Routes.superTiny: (_) => SuperTinyFormWidget(),
       },
       home: LoginFormWidget(),
     );

--- a/packages/reactive_forms_generator/example/lib/routes/array_nullable_form.dart
+++ b/packages/reactive_forms_generator/example/lib/routes/array_nullable_form.dart
@@ -52,7 +52,7 @@ class ArrayNullableFormWidget extends StatelessWidget {
                     onPressed: () {
                       final newEmail = 'other${contacts.length + 1}@email.com';
                       contacts.add(newEmail);
-                      formModel.emailListControl.add(
+                      formModel.emailListControl?.add(
                         FormControl<String>(value: newEmail),
                       );
                     },
@@ -82,7 +82,7 @@ class ArrayNullableFormWidget extends StatelessWidget {
                     onPressed: () {
                       final newFruit = 'otherFruit${fruits.length + 1}';
                       fruits.add(newFruit);
-                      formModel.fruitListControl.add(
+                      formModel.fruitListControl?.add(
                         FormControl<bool>(value: false),
                       );
                     },

--- a/packages/reactive_forms_generator/lib/src/form_generator.dart
+++ b/packages/reactive_forms_generator/lib/src/form_generator.dart
@@ -138,7 +138,7 @@ class FormGenerator {
       .toList();
 
   Method fieldValueMethod(ParameterElement field) {
-    String fieldValue = '${field.fieldControlName}.value';
+    String fieldValue = '${field.fieldControlName}?.value';
 
     if (field.isFormGroup) {
       fieldValue = '${field.fieldName}Form.model';
@@ -159,7 +159,7 @@ class FormGenerator {
 
       // fieldValue =
       //     '${field.name}${formGenerator.className}.map((e) => e.model).toList()';
-      fieldValue = '''(${field.fieldControlName}.value ?? [])
+      fieldValue = '''(${field.fieldControlName}?.value ?? [])
           .asMap()
           .map((k, v) => MapEntry(
             k,
@@ -172,7 +172,7 @@ class FormGenerator {
       final type = (field.type as ParameterizedType).typeArguments.first;
 
       fieldValue =
-          '${field.fieldControlName}.value?.whereType<${type.getDisplayString(
+          '${field.fieldControlName}?.value?.whereType<${type.getDisplayString(
         withNullability: true,
       )}>().toList() ?? []';
     }
@@ -219,7 +219,7 @@ class FormGenerator {
           ..type = MethodType.getter
           ..returns = const Reference('Object?')
           ..body = Code(
-            '${field.fieldControlName}.errors',
+            '${field.fieldControlName}?.errors',
           ),
       );
 
@@ -309,7 +309,7 @@ class FormGenerator {
         ])
         ..returns = const Reference('void')
         ..body = Code(
-          '${field.fieldControlName}.updateValue($value, updateParent: updateParent, emitEvent:emitEvent)',
+          '${field.fieldControlName}?.updateValue($value, updateParent: updateParent, emitEvent:emitEvent)',
         ),
     );
   }
@@ -356,7 +356,7 @@ class FormGenerator {
         ])
         ..returns = const Reference('void')
         ..body = Code(
-          '${field.fieldControlName}.patchValue($value, updateParent: updateParent, emitEvent:emitEvent)',
+          '${field.fieldControlName}?.patchValue($value, updateParent: updateParent, emitEvent:emitEvent)',
         ),
     );
   }
@@ -416,7 +416,7 @@ class FormGenerator {
         ])
         ..returns = const Reference('void')
         ..body = Code(
-          '${field.fieldControlName}.reset(value: $value, updateParent: updateParent, emitEvent:emitEvent)',
+          '${field.fieldControlName}?.reset(value: $value, updateParent: updateParent, emitEvent:emitEvent)',
         ),
     );
   }
@@ -587,16 +587,17 @@ class FormGenerator {
       displayType = displayType.substring(0, displayType.length - 1);
     }
 
-    final reference = 'FormControl<$displayType>';
+    final reference = 'FormControl<$displayType>?';
 
     return Method(
       (b) => b
         ..name = field.fieldControlName
-        ..lambda = true
         ..type = MethodType.getter
         ..returns = Reference(reference)
         ..body = Code(
-          'form.control(${field.fieldControlPath}()) as $reference',
+          '''if (contains${field.name.pascalCase}) {
+            return form.control(${field.fieldControlPath}()) as $reference;
+          }''',
         ),
     );
   }
@@ -610,16 +611,17 @@ class FormGenerator {
     //   displayType = displayType.substring(0, displayType.length - 1);
     // }
 
-    const reference = 'FormGroup';
+    const reference = 'FormGroup?';
 
     return Method(
       (b) => b
         ..name = field.fieldControlName
-        ..lambda = true
         ..type = MethodType.getter
         ..returns = const Reference(reference)
         ..body = Code(
-          'form.control(${field.fieldControlPath}()) as $reference',
+          '''if (contains${field.name.pascalCase}) {
+            return form.control(${field.fieldControlPath}()) as $reference;
+          }''',
         ),
     );
   }
@@ -635,20 +637,21 @@ class FormGenerator {
       displayType = displayType.substring(0, displayType.length - 1);
     }
 
-    String typeReference = 'FormArray<$displayType>';
+    String typeReference = 'FormArray<$displayType>?';
 
     if (field.isFormGroupArray) {
-      typeReference = 'FormArray<Map<String, Object?>>';
+      typeReference = 'FormArray<Map<String, Object?>>?';
     }
 
     return Method(
       (b) => b
         ..name = field.fieldControlName
-        ..lambda = true
         ..type = MethodType.getter
         ..returns = Reference(typeReference)
         ..body = Code(
-          'form.control(${field.fieldControlPath}()) as $typeReference',
+          '''if (contains${field.name.pascalCase}) {
+            return form.control(${field.fieldControlPath}()) as $typeReference;
+          }''',
         ),
     );
   }
@@ -674,7 +677,7 @@ class FormGenerator {
           '''
               final formGroup = ${formGroupGenerator.className}(value, form, pathBuilder('${field.fieldName}')).formElements();
 
-              ${field.fieldControlName}.add(formGroup);''',
+              ${field.fieldControlName}?.add(formGroup);''',
         ),
     );
   }
@@ -766,7 +769,7 @@ class FormGenerator {
                   break;
               }
                
-              ${field.fieldControlName}.add(FormControl<$type>(
+              ${field.fieldControlName}?.add(FormControl<$type>(
                 value: value, 
                 validators: resultingValidators,
                 asyncValidators: resultingAsyncValidators,


### PR DESCRIPTION
Hi @vasilich6107 First things first, I won't take offence if you don't use this. I thought it would be a fun challenge for me to take on. Feel free to fix it in another way if there is a better way. 

This will have to be a minor breaking change, because since we can remove form fields with the generated `remove()` functions, that means `FormControls`, `FormGroups`, and `FormArrays` need to be nullable. 

I will put this PR into draft status. This fixes issue #16. I have applied the complete fix and created a usage example, "Super Tiny Form", where I remove a `FormControl` field from the form by doing: `formModel.passwordRemove();` and don't get the exception when accessing the `formModel.model` fields. I need to do the same tests for removing `FormGroups` and `FormArrays`, so I will add two more example forms to the samples. 

Let me know your thoughts. I can also change any code to be the style of the package; for example, the newly generated `FormControl` getters have curly braces and newlines in between the functions, so that can be changed (it just generated the code that way by default, I didn't consciously try to do it that way). 

Cheers