### PR TITLE
Allow upgrades to analyzer

### DIFF
--- a/packages/generator_tests/pubspec.lock
+++ b/packages/generator_tests/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "64.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.2.0"
   args:
     dependency: transitive
     description:
@@ -193,14 +193,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  fake_async:
-    dependency: transitive
-    description:
-      name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   file:
     dependency: transitive
     description:
@@ -230,19 +222,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
-  flutter_test:
-    dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   freezed:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "2df89855fe181baae3b6d714dc3c4317acf4fccd495a6f36e5e00f24144c6c3b"
+      sha256: "83462cfc33dc9680533a7f3a4a6ab60aa94f287db5f4ee6511248c22833c497f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -586,26 +573,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.6"
   timing:
     dependency: transitive
     description:

--- a/packages/generator_tests/pubspec.yaml
+++ b/packages/generator_tests/pubspec.yaml
@@ -37,8 +37,6 @@ dev_dependencies:
   json_serializable:
   build_test: ^2.1.5
   freezed: ^2.2.0
-  flutter_test:
-    sdk: flutter
   test: ^1.21.1
   logging: ^1.0.2
   reactive_forms_generator:

--- a/packages/reactive_forms_generator/lib/src/types.dart
+++ b/packages/reactive_forms_generator/lib/src/types.dart
@@ -54,8 +54,14 @@ extension ParameterElementAnnotationExt on ParameterElement {
   }
 
   bool get hasRfArrayAnnotation {
-    return formArrayChecker.hasAnnotationOfExact(this) ||
-        formArrayCheckerRf.hasAnnotationOfExact(this);
+    return formArrayChecker.hasAnnotationOfExact(
+          this,
+          throwOnUnresolved: false,
+        ) ||
+        formArrayCheckerRf.hasAnnotationOfExact(
+          this,
+          throwOnUnresolved: false,
+        );
   }
 }
 

--- a/packages/reactive_forms_generator/pubspec.yaml
+++ b/packages/reactive_forms_generator/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   build: ^2.3.1
   source_gen: ^1.2.7
-  analyzer: ^5.7.1
+  analyzer: ">=5.12.0 <7.0.0"
   path: ^1.8.1
   build_runner: ^2.3.3
   code_builder: ^4.4.0
@@ -31,9 +31,7 @@ dependencies:
   recase: ^4.1.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  build_test: ^2.1.6
+  build_test: ^2.2.0
   logging: ^1.1.1
   flutter_lints: ^2.0.1
 


### PR DESCRIPTION
Remove dependency on flutter_test as form generator doesn't need it
This allows us to use an upgraded analyzer version