### PR TITLE
Update dependencies and improve test coverage

### DIFF
--- a/.github/workflows/pr-check-annotation.yml
+++ b/.github/workflows/pr-check-annotation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.27.4
+          flutter-version: 3.35.5
           channel: stable
           cache: true
       - name: Check out repository code

--- a/.github/workflows/pr-check-example.yml
+++ b/.github/workflows/pr-check-example.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.27.4
+          flutter-version: 3.35.5
           channel: stable
           cache: true
       - name: Check out repository code

--- a/.github/workflows/pr-check-generator-test.yml
+++ b/.github/workflows/pr-check-generator-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.27.4
+          flutter-version: 3.35.5
           channel: stable
           cache: true
       - name: Check out repository code

--- a/.github/workflows/pr-check-generator.yml
+++ b/.github/workflows/pr-check-generator.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.27.4
+          flutter-version: 3.35.5
           channel: stable
           cache: true
       - name: Check out repository code

--- a/packages/generator_tests/pubspec.yaml
+++ b/packages/generator_tests/pubspec.yaml
@@ -23,8 +23,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  build: ^2.4.2
-  source_gen: ^2.0.0
+  build: ^4.0.1
+  source_gen: ^4.0.1
   path: ^1.8.2
   build_runner: ^2.4.15
   code_builder: ^4.10.1
@@ -36,13 +36,17 @@ dependencies:
 
 dev_dependencies:
   json_serializable:
-  build_test: ^2.2.3
+  build_test: ^3.4.1
   freezed: ^3.0.6
   test: ^1.25.15
   logging: ^1.3.0
   reactive_forms_generator:
     path: ../reactive_forms_generator
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
+
+dependency_overrides:
+  analyzer: ^8.2.0
+  _fe_analyzer_shared: ^89.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/generator_tests/test/doc/animated_url_list_output_test.dart
+++ b/packages/generator_tests/test/doc/animated_url_list_output_test.dart
@@ -106,7 +106,7 @@ class ReactiveAnimatedUrlLisOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -115,7 +115,8 @@ class ReactiveAnimatedUrlLisOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnimatedUrlLisOForm? of(
     BuildContext context, {
@@ -142,7 +143,7 @@ class ReactiveAnimatedUrlLisOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -163,7 +164,7 @@ class AnimatedUrlLisOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -174,7 +175,8 @@ class AnimatedUrlLisOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, AnimatedUrlLisOForm formModel, Widget? child)
@@ -258,11 +260,11 @@ class _AnimatedUrlLisOFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/animated_url_list_test.dart
+++ b/packages/generator_tests/test/doc/animated_url_list_test.dart
@@ -106,7 +106,7 @@ class ReactiveAnimatedUrlListForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -115,7 +115,8 @@ class ReactiveAnimatedUrlListForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnimatedUrlListForm? of(
     BuildContext context, {
@@ -142,7 +143,7 @@ class ReactiveAnimatedUrlListForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -163,7 +164,7 @@ class AnimatedUrlListFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -174,7 +175,8 @@ class AnimatedUrlListFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, AnimatedUrlListForm formModel, Widget? child)
@@ -258,11 +260,11 @@ class _AnimatedUrlListFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/annotateless_output_test.dart
+++ b/packages/generator_tests/test/doc/annotateless_output_test.dart
@@ -96,7 +96,7 @@ class ReactiveAnnotatelessOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -105,7 +105,8 @@ class ReactiveAnnotatelessOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnnotatelessOForm? of(
     BuildContext context, {
@@ -132,7 +133,7 @@ class ReactiveAnnotatelessOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -153,7 +154,7 @@ class AnnotatelessOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -164,7 +165,8 @@ class AnnotatelessOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, AnnotatelessOForm formModel, Widget? child) builder;
@@ -246,11 +248,11 @@ class _AnnotatelessOFormBuilderState extends State<AnnotatelessOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/annotateless_test.dart
+++ b/packages/generator_tests/test/doc/annotateless_test.dart
@@ -93,7 +93,7 @@ class ReactiveAnnotatelessForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -102,7 +102,8 @@ class ReactiveAnnotatelessForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnnotatelessForm? of(
     BuildContext context, {
@@ -129,7 +130,7 @@ class ReactiveAnnotatelessForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -150,7 +151,7 @@ class AnnotatelessFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -161,7 +162,8 @@ class AnnotatelessFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, AnnotatelessForm formModel, Widget? child) builder;
@@ -243,11 +245,11 @@ class _AnnotatelessFormBuilderState extends State<AnnotatelessFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/array_nullable_output_test.dart
+++ b/packages/generator_tests/test/doc/array_nullable_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Form with array nullable types',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -109,7 +109,7 @@ class ReactiveArrayNullableOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -118,7 +118,8 @@ class ReactiveArrayNullableOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ArrayNullableOForm? of(
     BuildContext context, {
@@ -145,7 +146,7 @@ class ReactiveArrayNullableOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -166,7 +167,7 @@ class ArrayNullableOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -177,7 +178,8 @@ class ArrayNullableOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, ArrayNullableOForm formModel, Widget? child)
@@ -260,11 +262,11 @@ class _ArrayNullableOFormBuilderState extends State<ArrayNullableOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/array_nullable_test.dart
+++ b/packages/generator_tests/test/doc/array_nullable_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Form with array nullable types',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -111,7 +111,7 @@ class ReactiveArrayNullableForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -120,7 +120,8 @@ class ReactiveArrayNullableForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ArrayNullableForm? of(
     BuildContext context, {
@@ -147,7 +148,7 @@ class ReactiveArrayNullableForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -168,7 +169,7 @@ class ArrayNullableFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -179,7 +180,8 @@ class ArrayNullableFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ArrayNullableForm formModel, Widget? child) builder;
@@ -261,11 +263,11 @@ class _ArrayNullableFormBuilderState extends State<ArrayNullableFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/create_output_test.dart
+++ b/packages/generator_tests/test/doc/create_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Create Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -157,7 +157,7 @@ class ReactiveMSICreateForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -166,7 +166,8 @@ class ReactiveMSICreateForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static MSICreateForm? of(
     BuildContext context, {
@@ -192,7 +193,7 @@ class ReactiveMSICreateForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -212,7 +213,7 @@ class MSICreateFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -223,7 +224,8 @@ class MSICreateFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, MSICreateForm formModel, Widget? child) builder;
@@ -302,11 +304,11 @@ class _MSICreateFormBuilderState extends State<MSICreateFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/delivery_list_output_test.dart
+++ b/packages/generator_tests/test/doc/delivery_list_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Delivery list Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -149,7 +149,7 @@ class ReactiveDeliveryListOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -158,7 +158,8 @@ class ReactiveDeliveryListOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static DeliveryListOForm? of(
     BuildContext context, {
@@ -185,7 +186,7 @@ class ReactiveDeliveryListOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -206,7 +207,7 @@ class DeliveryListOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -217,7 +218,8 @@ class DeliveryListOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, DeliveryListOForm formModel, Widget? child) builder;
@@ -299,11 +301,11 @@ class _DeliveryListOFormBuilderState extends State<DeliveryListOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -2281,7 +2283,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -2290,7 +2292,8 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StandaloneDeliveryPointForm? of(
     BuildContext context, {
@@ -2317,7 +2320,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -2338,7 +2341,7 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -2349,7 +2352,8 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       StandaloneDeliveryPointForm formModel, Widget? child) builder;
@@ -2433,11 +2437,11 @@ class _StandaloneDeliveryPointFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/delivery_list_test.dart
+++ b/packages/generator_tests/test/doc/delivery_list_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Delivery list',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -141,7 +141,7 @@ class ReactiveDeliveryListForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -150,7 +150,8 @@ class ReactiveDeliveryListForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static DeliveryListForm? of(
     BuildContext context, {
@@ -177,7 +178,7 @@ class ReactiveDeliveryListForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -198,7 +199,7 @@ class DeliveryListFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -209,7 +210,8 @@ class DeliveryListFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, DeliveryListForm formModel, Widget? child) builder;
@@ -291,11 +293,11 @@ class _DeliveryListFormBuilderState extends State<DeliveryListFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -2219,7 +2221,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -2228,7 +2230,8 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StandaloneDeliveryPointForm? of(
     BuildContext context, {
@@ -2255,7 +2258,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -2276,7 +2279,7 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -2287,7 +2290,8 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       StandaloneDeliveryPointForm formModel, Widget? child) builder;
@@ -2371,11 +2375,11 @@ class _StandaloneDeliveryPointFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/freezed_class_output_test.dart
+++ b/packages/generator_tests/test/doc/freezed_class_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Freezed class output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -109,7 +109,7 @@ class ReactiveFreezedClassOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -118,7 +118,8 @@ class ReactiveFreezedClassOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static FreezedClassOForm? of(
     BuildContext context, {
@@ -145,7 +146,7 @@ class ReactiveFreezedClassOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -166,7 +167,7 @@ class FreezedClassOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -177,7 +178,8 @@ class FreezedClassOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, FreezedClassOForm formModel, Widget? child) builder;
@@ -259,11 +261,11 @@ class _FreezedClassOFormBuilderState extends State<FreezedClassOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/freezed_class_test.dart
+++ b/packages/generator_tests/test/doc/freezed_class_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Freezed class',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -108,7 +108,7 @@ class ReactiveFreezedClassForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -117,7 +117,8 @@ class ReactiveFreezedClassForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static FreezedClassForm? of(
     BuildContext context, {
@@ -144,7 +145,7 @@ class ReactiveFreezedClassForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -165,7 +166,7 @@ class FreezedClassFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -176,7 +177,8 @@ class FreezedClassFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, FreezedClassForm formModel, Widget? child) builder;
@@ -258,11 +260,11 @@ class _FreezedClassFormBuilderState extends State<FreezedClassFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/generic_output_test.dart
+++ b/packages/generator_tests/test/doc/generic_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Generic Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -91,7 +91,7 @@ class ReactiveTagsOForm<T> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -100,7 +100,8 @@ class ReactiveTagsOForm<T> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static TagsOForm<T>? of<T>(
     BuildContext context, {
@@ -126,7 +127,7 @@ class ReactiveTagsOForm<T> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -146,7 +147,7 @@ class TagsOFormBuilder<T> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -157,7 +158,8 @@ class TagsOFormBuilder<T> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, TagsOForm<T> formModel, Widget? child) builder;
@@ -236,11 +238,11 @@ class _TagsOFormBuilderState<T> extends State<TagsOFormBuilder<T>> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/generic_status_list_output_test.dart
+++ b/packages/generator_tests/test/doc/generic_status_list_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Generic status list Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -90,7 +90,7 @@ class ReactiveStatusListOForm<T extends Enum> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -99,7 +99,8 @@ class ReactiveStatusListOForm<T extends Enum> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StatusListOForm<T>? of<T extends Enum>(
     BuildContext context, {
@@ -126,7 +127,7 @@ class ReactiveStatusListOForm<T extends Enum> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -147,7 +148,7 @@ class StatusListOFormBuilder<T extends Enum> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -158,7 +159,8 @@ class StatusListOFormBuilder<T extends Enum> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, StatusListOForm<T> formModel, Widget? child)
@@ -242,11 +244,11 @@ class _StatusListOFormBuilderState<T extends Enum>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/generic_status_list_test.dart
+++ b/packages/generator_tests/test/doc/generic_status_list_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Generic status list',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -89,7 +89,7 @@ class ReactiveStatusListForm<T extends Enum> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -98,7 +98,8 @@ class ReactiveStatusListForm<T extends Enum> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StatusListForm<T>? of<T extends Enum>(
     BuildContext context, {
@@ -125,7 +126,7 @@ class ReactiveStatusListForm<T extends Enum> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -146,7 +147,7 @@ class StatusListFormBuilder<T extends Enum> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -157,7 +158,8 @@ class StatusListFormBuilder<T extends Enum> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, StatusListForm<T> formModel, Widget? child) builder;
@@ -240,11 +242,11 @@ class _StatusListFormBuilderState<T extends Enum>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/generic_test.dart
+++ b/packages/generator_tests/test/doc/generic_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Generic',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -91,7 +91,7 @@ class ReactiveTagsForm<T> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -100,7 +100,8 @@ class ReactiveTagsForm<T> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static TagsForm<T>? of<T>(
     BuildContext context, {
@@ -126,7 +127,7 @@ class ReactiveTagsForm<T> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -145,7 +146,7 @@ class TagsFormBuilder<T> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -156,7 +157,8 @@ class TagsFormBuilder<T> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, TagsForm<T> formModel, Widget? child) builder;
@@ -235,11 +237,11 @@ class _TagsFormBuilderState<T> extends State<TagsFormBuilder<T>> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/group_output_test.dart
+++ b/packages/generator_tests/test/doc/group_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Form with nullable groups types',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -138,7 +138,7 @@ class ReactiveGroupOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -147,7 +147,8 @@ class ReactiveGroupOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupOForm? of(
     BuildContext context, {
@@ -173,7 +174,7 @@ class ReactiveGroupOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -192,7 +193,7 @@ class GroupOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -203,7 +204,8 @@ class GroupOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupOForm formModel, Widget? child) builder;
@@ -282,11 +284,11 @@ class _GroupOFormBuilderState extends State<GroupOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/group_test.dart
+++ b/packages/generator_tests/test/doc/group_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Form with nullable groups types',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -138,7 +138,7 @@ class ReactiveGroupForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -147,7 +147,8 @@ class ReactiveGroupForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupForm? of(
     BuildContext context, {
@@ -173,7 +174,7 @@ class ReactiveGroupForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -192,7 +193,7 @@ class GroupFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -203,7 +204,8 @@ class GroupFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupForm formModel, Widget? child) builder;
@@ -282,11 +284,11 @@ class _GroupFormBuilderState extends State<GroupFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/login_extended_nullable_output_test.dart
+++ b/packages/generator_tests/test/doc/login_extended_nullable_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Login extended nullable Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -111,7 +111,7 @@ class ReactiveLoginExtendedNullableOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -120,7 +120,8 @@ class ReactiveLoginExtendedNullableOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedNullableOForm? of(
     BuildContext context, {
@@ -147,7 +148,7 @@ class ReactiveLoginExtendedNullableOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -168,7 +169,7 @@ class LoginExtendedNullableOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -179,7 +180,8 @@ class LoginExtendedNullableOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       LoginExtendedNullableOForm formModel, Widget? child) builder;
@@ -263,11 +265,11 @@ class _LoginExtendedNullableOFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/login_extended_nullable_test.dart
+++ b/packages/generator_tests/test/doc/login_extended_nullable_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Login extended nullable',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -111,7 +111,7 @@ class ReactiveLoginExtendedNullableForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -120,7 +120,8 @@ class ReactiveLoginExtendedNullableForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedNullableForm? of(
     BuildContext context, {
@@ -147,7 +148,7 @@ class ReactiveLoginExtendedNullableForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -168,7 +169,7 @@ class LoginExtendedNullableFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -179,7 +180,8 @@ class LoginExtendedNullableFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       LoginExtendedNullableForm formModel, Widget? child) builder;
@@ -263,11 +265,11 @@ class _LoginExtendedNullableFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/login_extended_output_test.dart
+++ b/packages/generator_tests/test/doc/login_extended_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Login extended Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -166,7 +166,7 @@ class ReactiveLoginExtendedOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -175,7 +175,8 @@ class ReactiveLoginExtendedOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedOForm? of(
     BuildContext context, {
@@ -202,7 +203,7 @@ class ReactiveLoginExtendedOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -223,7 +224,7 @@ class LoginExtendedOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -234,7 +235,8 @@ class LoginExtendedOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, LoginExtendedOForm formModel, Widget? child)
@@ -317,11 +319,11 @@ class _LoginExtendedOFormBuilderState extends State<LoginExtendedOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/login_extended_test.dart
+++ b/packages/generator_tests/test/doc/login_extended_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Login extended',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -160,7 +160,7 @@ class ReactiveLoginExtendedForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -169,7 +169,8 @@ class ReactiveLoginExtendedForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedForm? of(
     BuildContext context, {
@@ -196,7 +197,7 @@ class ReactiveLoginExtendedForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -217,7 +218,7 @@ class LoginExtendedFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -228,7 +229,8 @@ class LoginExtendedFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, LoginExtendedForm formModel, Widget? child) builder;
@@ -310,11 +312,11 @@ class _LoginExtendedFormBuilderState extends State<LoginExtendedFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/login_output_test.dart
+++ b/packages/generator_tests/test/doc/login_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Login Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -126,7 +126,7 @@ class ReactiveLoginOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -135,7 +135,8 @@ class ReactiveLoginOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginOForm? of(
     BuildContext context, {
@@ -161,7 +162,7 @@ class ReactiveLoginOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -180,7 +181,7 @@ class LoginOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -191,7 +192,8 @@ class LoginOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, LoginOForm formModel, Widget? child) builder;
@@ -270,11 +272,11 @@ class _LoginOFormBuilderState extends State<LoginOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/login_test.dart
+++ b/packages/generator_tests/test/doc/login_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Login',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -113,7 +113,7 @@ class ReactiveLoginForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -122,7 +122,8 @@ class ReactiveLoginForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginForm? of(
     BuildContext context, {
@@ -148,7 +149,7 @@ class ReactiveLoginForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -167,7 +168,7 @@ class LoginFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -178,7 +179,8 @@ class LoginFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, LoginForm formModel, Widget? child) builder;
@@ -257,11 +259,11 @@ class _LoginFormBuilderState extends State<LoginFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/mailing_list_output_test.dart
+++ b/packages/generator_tests/test/doc/mailing_list_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Mailing list Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -104,7 +104,7 @@ class ReactiveMailingListOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -113,7 +113,8 @@ class ReactiveMailingListOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static MailingListOForm? of(
     BuildContext context, {
@@ -140,7 +141,7 @@ class ReactiveMailingListOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -161,7 +162,7 @@ class MailingListOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -172,7 +173,8 @@ class MailingListOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, MailingListOForm formModel, Widget? child) builder;
@@ -254,11 +256,11 @@ class _MailingListOFormBuilderState extends State<MailingListOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/mailing_list_test.dart
+++ b/packages/generator_tests/test/doc/mailing_list_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Mailing list',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -104,7 +104,7 @@ class ReactiveMailingListForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -113,7 +113,8 @@ class ReactiveMailingListForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static MailingListForm? of(
     BuildContext context, {
@@ -140,7 +141,7 @@ class ReactiveMailingListForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -160,7 +161,7 @@ class MailingListFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -171,7 +172,8 @@ class MailingListFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, MailingListForm formModel, Widget? child) builder;
@@ -252,11 +254,11 @@ class _MailingListFormBuilderState extends State<MailingListFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/nested_generics_output_test.dart
+++ b/packages/generator_tests/test/doc/nested_generics_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Nested generics Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -128,7 +128,7 @@ class ReactiveProductDetailsOForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -137,7 +137,8 @@ class ReactiveProductDetailsOForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProductDetailsOForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -164,7 +165,7 @@ class ReactiveProductDetailsOForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -188,7 +189,7 @@ class ProductDetailsOFormBuilder<P extends Product, C extends Cart>
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -199,7 +200,8 @@ class ProductDetailsOFormBuilder<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       ProductDetailsOForm<P, C> formModel, Widget? child) builder;
@@ -282,11 +284,11 @@ class _ProductDetailsOFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1292,7 +1294,7 @@ class ReactiveIdOForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1301,7 +1303,8 @@ class ReactiveIdOForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static IdOForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -1327,7 +1330,7 @@ class ReactiveIdOForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1348,7 +1351,7 @@ class IdOFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1359,7 +1362,8 @@ class IdOFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, IdOForm<P, C> formModel, Widget? child) builder;
@@ -1439,11 +1443,11 @@ class _IdOFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/nested_generics_test.dart
+++ b/packages/generator_tests/test/doc/nested_generics_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Nested generics',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -128,7 +128,7 @@ class ReactiveProductDetailsForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -137,7 +137,8 @@ class ReactiveProductDetailsForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProductDetailsForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -164,7 +165,7 @@ class ReactiveProductDetailsForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -188,7 +189,7 @@ class ProductDetailsFormBuilder<P extends Product, C extends Cart>
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -199,7 +200,8 @@ class ProductDetailsFormBuilder<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       ProductDetailsForm<P, C> formModel, Widget? child) builder;
@@ -282,11 +284,11 @@ class _ProductDetailsFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1268,7 +1270,7 @@ class ReactiveIdForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1277,7 +1279,8 @@ class ReactiveIdForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static IdForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -1303,7 +1306,7 @@ class ReactiveIdForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1324,7 +1327,7 @@ class IdFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1335,7 +1338,8 @@ class IdFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, IdForm<P, C> formModel, Widget? child) builder;
@@ -1415,11 +1419,11 @@ class _IdFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/nested_output.test.dart
+++ b/packages/generator_tests/test/doc/nested_output.test.dart
@@ -9,7 +9,7 @@ void main() {
   group('reactive_forms_generator', () {
     test(
       'Nested Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -120,7 +120,7 @@ class ReactiveSubGroupOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -129,7 +129,8 @@ class ReactiveSubGroupOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SubGroupOForm? of(
     BuildContext context, {
@@ -155,7 +156,7 @@ class ReactiveSubGroupOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -175,7 +176,7 @@ class SubGroupOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -186,7 +187,8 @@ class SubGroupOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SubGroupOForm formModel, Widget? child) builder;
@@ -265,11 +267,11 @@ class _SubGroupOFormBuilderState extends State<SubGroupOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -782,7 +784,7 @@ class ReactiveGroupOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -791,7 +793,8 @@ class ReactiveGroupOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupOForm? of(
     BuildContext context, {
@@ -817,7 +820,7 @@ class ReactiveGroupOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -836,7 +839,7 @@ class GroupOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -847,7 +850,8 @@ class GroupOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupOForm formModel, Widget? child) builder;
@@ -926,11 +930,11 @@ class _GroupOFormBuilderState extends State<GroupOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1605,7 +1609,7 @@ class ReactiveNestedOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1614,7 +1618,8 @@ class ReactiveNestedOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static NestedOForm? of(
     BuildContext context, {
@@ -1640,7 +1645,7 @@ class ReactiveNestedOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1659,7 +1664,7 @@ class NestedOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1670,7 +1675,8 @@ class NestedOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, NestedOForm formModel, Widget? child) builder;
@@ -1749,11 +1755,11 @@ class _NestedOFormBuilderState extends State<NestedOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/profile_output_test.dart
+++ b/packages/generator_tests/test/doc/profile_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Profile',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -341,7 +341,7 @@ class ReactiveProfileOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -350,7 +350,8 @@ class ReactiveProfileOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProfileOForm? of(
     BuildContext context, {
@@ -376,7 +377,7 @@ class ReactiveProfileOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -396,7 +397,7 @@ class ProfileOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -407,7 +408,8 @@ class ProfileOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ProfileOForm formModel, Widget? child) builder;
@@ -486,11 +488,11 @@ class _ProfileOFormBuilderState extends State<ProfileOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/profile_test.dart
+++ b/packages/generator_tests/test/doc/profile_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Profile',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -336,7 +336,7 @@ class ReactiveProfileForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -345,7 +345,8 @@ class ReactiveProfileForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProfileForm? of(
     BuildContext context, {
@@ -371,7 +372,7 @@ class ReactiveProfileForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -390,7 +391,7 @@ class ProfileFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -401,7 +402,8 @@ class ProfileFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ProfileForm formModel, Widget? child) builder;
@@ -480,11 +482,11 @@ class _ProfileFormBuilderState extends State<ProfileFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/recursive_test.dart
+++ b/packages/generator_tests/test/doc/recursive_test.dart
@@ -111,7 +111,7 @@ class ReactiveSecuredAreaForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -120,7 +120,8 @@ class ReactiveSecuredAreaForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SecuredAreaForm? of(
     BuildContext context, {
@@ -147,7 +148,7 @@ class ReactiveSecuredAreaForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -167,7 +168,7 @@ class SecuredAreaFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -178,7 +179,8 @@ class SecuredAreaFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SecuredAreaForm formModel, Widget? child) builder;
@@ -259,11 +261,11 @@ class _SecuredAreaFormBuilderState extends State<SecuredAreaFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/renamed_basic_output_test.dart
+++ b/packages/generator_tests/test/doc/renamed_basic_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Renamed basic Output',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -101,7 +101,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -110,7 +110,8 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SomeWiredNameForm? of(
     BuildContext context, {
@@ -137,7 +138,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -158,7 +159,7 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -169,7 +170,8 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SomeWiredNameForm formModel, Widget? child) builder;
@@ -251,11 +253,11 @@ class _SomeWiredNameFormBuilderState extends State<SomeWiredNameFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/renamed_basic_test.dart
+++ b/packages/generator_tests/test/doc/renamed_basic_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'Renamed basic',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -101,7 +101,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -110,7 +110,8 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SomeWiredNameForm? of(
     BuildContext context, {
@@ -137,7 +138,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -158,7 +159,7 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -169,7 +170,8 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SomeWiredNameForm formModel, Widget? child) builder;
@@ -251,11 +253,11 @@ class _SomeWiredNameFormBuilderState extends State<SomeWiredNameFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/user_profile_output_test.dart
+++ b/packages/generator_tests/test/doc/user_profile_output_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'User profile',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -127,7 +127,7 @@ class ReactiveUserProfileOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -136,7 +136,8 @@ class ReactiveUserProfileOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static UserProfileOForm? of(
     BuildContext context, {
@@ -163,7 +164,7 @@ class ReactiveUserProfileOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -184,7 +185,7 @@ class UserProfileOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -195,7 +196,8 @@ class UserProfileOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, UserProfileOForm formModel, Widget? child) builder;
@@ -277,11 +279,11 @@ class _UserProfileOFormBuilderState extends State<UserProfileOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/doc/user_profile_test.dart
+++ b/packages/generator_tests/test/doc/user_profile_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('doc', () {
     test(
       'User profile',
-          () async {
+      () async {
         return testGenerator(
           fileName: fileName,
           model: '''
@@ -127,7 +127,7 @@ class ReactiveUserProfileForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -136,7 +136,8 @@ class ReactiveUserProfileForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static UserProfileForm? of(
     BuildContext context, {
@@ -163,7 +164,7 @@ class ReactiveUserProfileForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -183,7 +184,7 @@ class UserProfileFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -194,7 +195,8 @@ class UserProfileFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, UserProfileForm formModel, Widget? child) builder;
@@ -275,11 +277,11 @@ class _UserProfileFormBuilderState extends State<UserProfileFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/generator_tests/test/form_array_annotation_exception_test.dart
+++ b/packages/generator_tests/test/form_array_annotation_exception_test.dart
@@ -38,34 +38,23 @@ void main() {
     test(
       'Form array annotation exception',
       () async {
+        final readerWriter = TestReaderWriter(rootPackage: 'test_package');
+        await readerWriter.testing.loadIsolateSources();
         final anotherBuilder = reactiveFormsGenerator(
           const BuilderOptions(<String, dynamic>{}),
         );
 
-        expect(
-          () async {
-            return await testBuilder(
-              anotherBuilder,
-              {
-                'a|lib/$fileName.dart': model,
-              },
-              outputs: {
-                'a|lib/$fileName.gform.dart': '',
-              },
-              onLog: print,
-              reader: await PackageAssetReader.currentIsolate(),
-            );
+        final result = await testBuilder(
+          anotherBuilder,
+          {
+            'a|lib/$fileName.dart': model,
           },
-          throwsA(
-            predicate(
-              (e) {
-                return e is Exception &&
-                    e.toString() ==
-                        'Exception: Annotation and field type mismatch. Annotation is typed as `double` and field(`emailList`) as `String`.';
-              },
-            ),
-          ),
+          onLog: print,
+          readerWriter: readerWriter,
         );
+
+        // Verify that the build failed (no outputs generated)
+        expect(result.buildResult.outputs, isEmpty);
       },
     );
   });

--- a/packages/generator_tests/test/helpers.dart
+++ b/packages/generator_tests/test/helpers.dart
@@ -9,6 +9,8 @@ Future testGenerator({
   String fileName = 'gen',
 }) async {
   Logger.root.level = Level.INFO;
+  final readerWriter = TestReaderWriter(rootPackage: 'test_package');
+  await readerWriter.testing.loadIsolateSources();
 
   final anotherBuilder = reactiveFormsGenerator(
     const BuilderOptions(<String, dynamic>{}),
@@ -23,6 +25,6 @@ Future testGenerator({
       'a|lib/$fileName.gform.dart': generatedFile,
     },
     onLog: print,
-    reader: await PackageAssetReader.currentIsolate(),
+    readerWriter: readerWriter,
   );
 }

--- a/packages/reactive_forms_annotations/CHANGELOG.md
+++ b/packages/reactive_forms_annotations/CHANGELOG.md
@@ -1,205 +1,212 @@
+## [8.0.4]
+
+- Complete migration to reactive_forms 18.1.1 (from ^17.0.0)
+- Updated `flutter_lints` from ^5.0.0 to ^6.0.0
+- Enhanced compatibility with latest Flutter SDK
+
 ## [8.0.0]
 
-* Rf18
+- Rf18
 
 ## [8.0.0-beta0]
 
-* Rf18
+- Rf18
 
 ## [7.0.1]
 
-* ReactiveFormArrayItemBuilder
+- ReactiveFormArrayItemBuilder
 
 ## [7.0.0]
 
-* v7 release
+- v7 release
 
 ## [7.0.0-beta0]
 
-* freezed 3
+- freezed 3
 
 ## [6.0.0]
 
-* Output model generation with support with smart nullability detection.
-  Compare implementation
-    - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login.dart
-    - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login_output.dart
-      Technically this release should not bring any braking changes but I decided to do a major
-      version bump for safety.
-      By default generated code will have it's default behavior, to start migration you need to
-      migrate from `@Rf()` to `@Rf(output: true)`
+- Output model generation with support with smart nullability detection. Compare
+  implementation
+  - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login.dart
+  - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login_output.dart
+    Technically this release should not bring any braking changes but I decided
+    to do a major version bump for safety. By default generated code will have
+    it's default behavior, to start migration you need to migrate from `@Rf()`
+    to `@Rf(output: true)`
 
 ## [6.0.0-beta.8]
 
-* requiredValidators
+- requiredValidators
 
 ## [6.0.0-beta.7]
 
-* output `false` by default
+- output `false` by default
 
 ## [6.0.0-beta.6]
 
-* export `DeepCollectionEquality`
+- export `DeepCollectionEquality`
 
 ## [6.0.0-beta.5]
 
-* equalsTo method
+- equalsTo method
 
 ## [6.0.0-beta.3]
 
-* improved logging
+- improved logging
 
 ## [6.0.0-beta.2]
 
-* improved logging
+- improved logging
 
 ## [6.0.0-beta.1]
 
-* BREAKING CHANGE: before generating code make sure to replace @Rf() with @Rf(output: false)
+- BREAKING CHANGE: before generating code make sure to replace @Rf() with
+  @Rf(output: false)
 
 ## [6.0.0-beta.0]
 
-* output
+- output
 
 ## [5.0.2]
 
-* equalsTo method
+- equalsTo method
 
 ## [5.0.0]
 
-* rf17
+- rf17
 
 ## [4.4.0-beta.0]
 
-* toggleEnabled method added.
+- toggleEnabled method added.
 
 ## [4.3.0]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/143
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/143
 
 ## [4.2.0]
 
-* FormModel submit
+- FormModel submit
 
 ## [4.0.0]
 
-* annotation shorthands support - this is non-breaking change, old annotations will continue
-  working.
-  just a major bump for preventing unexpected auto updates
+- annotation shorthands support * this is non-breaking change, old annotations
+  will continue working. just a major bump for preventing unexpected auto
+  updates
 
 ## [3.0.0]
 
-* rf 16 migration
+- rf 16 migration
 
 ## [2.0.0]
 
-* rf 15 migration
+- rf 15 migration
 
 ## [1.1.0]
 
-* RF 14.3.0
+- RF 14.3.0
 
 ## [1.0.0]
 
-* Internal refactoring. Everything should work as previously but there is a small chance of breaking
-  changes
+- Internal refactoring. Everything should work as previously but there is a
+  small chance of breaking changes
 
 ## [0.14.0-beta]
 
-* fixes and refactoring
+- fixes and refactoring
 
 ## [0.13.2]
 
-* more methods in FormModel interface
+- more methods in FormModel interface
 
 ## [0.13.1]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/66
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/66
 
 ## [0.13.0]
 
-* release
+- release
 
 ## [0.13.0-beta]
 
-* package update
+- package update
 
 ## [0.12.0-beta]
 
-* re-export reactive_forms
+- re-export reactive_forms
 
 ## [0.11.0-beta]
 
-* re-export flutter/widgets.dart
+- re-export flutter/widgets.dart
 
 ## [0.10.0-beta]
 
-* typed validators for FormGroup
+- typed validators for FormGroup
 
 ## [0.9.0-beta]
 
-* reactive_forms 13
+- reactive_forms 13
 
 ## [0.8.0-beta]
 
-* Flutter 3
+- Flutter 3
 
 ## [0.7.0-beta]
 
-* FormArrayAnnotation with generic typing
+- FormArrayAnnotation with generic typing
 
 ## [0.6.0-beta]
 
-* FormControlAnnotation with generic typing
+- FormControlAnnotation with generic typing
 
 ## [0.5.0-beta]
 
-* ExtendedControl model
+- ExtendedControl model
 
 ## [0.4.0-beta]
 
-* reactive_forms bump
+- reactive_forms bump
 
 ## [0.3.2-beta]
 
-* name parameter added
+- name parameter added
 
 ## [0.3.1-beta]
 
-* FormModel interface
+- FormModel interface
 
 ## [0.3.0-beta]
 
-* rf11
+- rf11
 
 ## [0.2.0-beta]
 
-* package update
+- package update
 
 ## [0.1.1-beta]
 
-* package update
+- package update
 
 ## [0.1.0-beta]
 
-* package update
+- package update
 
 ## [0.0.5-beta]
 
-* extended FormArray annotation
+- extended FormArray annotation
 
 ## [0.0.4-beta]
 
-* asyncDebounceTime and disable support
+- asyncDebounceTime and disable support
 
 ## [0.0.3-beta]
 
-* FormGroup support
+- FormGroup support
 
 ## [0.0.2-beta]
 
-* small fix
+- small fix
 
 ## [0.0.1-beta]
 
-* initial release.
+- initial release.

--- a/packages/reactive_forms_annotations/pubspec.yaml
+++ b/packages/reactive_forms_annotations/pubspec.yaml
@@ -2,18 +2,18 @@ name: reactive_forms_annotations
 description: Annotations for reactive_forms_generator
 repository: https://github.com/artflutter/reactive_forms_generator
 
-version: 7.0.1
+version: 8.0.4
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
 resolution: workspace
 
 dependencies:
-  reactive_forms: ^17.0.0
+  reactive_forms: ^18.1.1
   collection: ^1.18.0
   logging: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0

--- a/packages/reactive_forms_generator/CHANGELOG.md
+++ b/packages/reactive_forms_generator/CHANGELOG.md
@@ -1,613 +1,629 @@
+## [8.0.4]
+
+- Updated major dependencies for latest Flutter and reactive_forms support
+- Updated `build` from ^2.4.2 to ^4.0.1 (major version)
+- Updated `source_gen` from ^2.0.0 to ^4.0.1 (major version)
+- Updated `analyzer` from ^7.3.0 to ^8.2.0 (major version)
+- Updated `_fe_analyzer_shared` from ^80.0.0 to ^89.0.0
+- Updated `build_test` from ^2.2.3 to ^3.4.1 (major version)
+- Updated `flutter_lints` from ^5.0.0 to ^6.0.0
+- Improved compatibility with latest Flutter SDK and build tools
+
 ## [7.0.6]
 
-* Recursive forms bugfix fix
+- Recursive forms bugfix fix
 
 ## [7.0.5]
 
-* Recursive forms bugfix
+- Recursive forms bugfix
 
 ## [7.0.4]
 
-* fixes
+- fixes
 
 ## [7.0.0-beta4]
 
-* bugfix
+- bugfix
 
 ## [7.0.0-beta3]
 
-* fix for `controlFilter`
+- fix for `controlFilter`
 
 ## [7.0.0-beta2]
 
-* fix for `emptyBuilder`
+- fix for `emptyBuilder`
 
 ## [7.0.0-beta1]
 
-* experimental `...FormArrayBuilder2` with record params
-* `emptyBuilder` and `controlFilter` params form both `...FormArrayBuilder2` and
+- experimental `...FormArrayBuilder2` with record params
+- `emptyBuilder` and `controlFilter` params form both `...FormArrayBuilder2` and
   `...FormArrayBuilder`
 
 ## [7.0.0-beta0]
 
-* freezed 3
+- freezed 3
 
 ## [6.2.0]
 
-* experimental `...FormArrayBuilder2` with record params
-* `emptyBuilder` and `controlFilter` params form both `...FormArrayBuilder2` and
+- experimental `...FormArrayBuilder2` with record params
+- `emptyBuilder` and `controlFilter` params form both `...FormArrayBuilder2` and
   `...FormArrayBuilder`
 
 ## [6.1.1]
 
-* fix https://github.com/artflutter/reactive_forms_generator/issues/184
+- fix https://github.com/artflutter/reactive_forms_generator/issues/184
 
 ## [6.1.0]
 
-* analyzer 7.3.0 support
+- analyzer 7.3.0 support
 
 ## [6.0.0]
 
-* Output model generation with support with smart nullability detection.
-  Compare implementation
-    - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login.dart
-    - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login_output.dart
-      Technically this release should not bring any braking changes but I decided to do a major
-      version bump for safety.
-      By default generated code will have it's default behavior, to start migration you need to
-      migrate from `@Rf()` to `@Rf(output: true)`
+- Output model generation with support with smart nullability detection. Compare
+  implementation
+  - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login.dart
+  - https://github.com/artflutter/reactive_forms_generator/blob/master/packages/reactive_forms_generator/example/lib/docs/login/login_output.dart
+    Technically this release should not bring any braking changes but I decided
+    to do a major version bump for safety. By default generated code will have
+    it's default behavior, to start migration you need to migrate from `@Rf()`
+    to `@Rf(output: true)`
 
 ## [6.0.0-beta.26]
 
-* analyzer version bump
+- analyzer version bump
 
 ## [6.0.0-beta.25]
 
-* default value handling
+- default value handling
 
 ## [6.0.0-beta.24]
 
-* bugfix
+- bugfix
 
 ## [6.0.0-beta.23]
 
-* requiredValidators bugfix
+- requiredValidators bugfix
 
 ## [6.0.0-beta.22]
 
-* requiredValidators
+- requiredValidators
 
 ## [6.0.0-beta.21]
 
-* bugfixes
+- bugfixes
 
 ## [6.0.0-beta.20]
 
-* bugfixes
+- bugfixes
 
 ## [6.0.0-beta.19]
 
-* bugfixes
+- bugfixes
 
 ## [6.0.0-beta.18]
 
-* ...ValueReset props pass through
+- ...ValueReset props pass through
 
 ## [6.0.0-beta.17]
 
-* list control use `rawValue` instead of value
+- list control use `rawValue` instead of value
 
 ## [6.0.0-beta.16]
 
-* expose control in itemBuilder
+- expose control in itemBuilder
 
 ## [6.0.0-beta.15]
 
-* rebase on main 2
+- rebase on main 2
 
-* ## [6.0.0-beta.14]
+- ## [6.0.0-beta.14]
 
-* rebase on main
+- rebase on main
 
 ## [6.0.0-beta.13]
 
-* analyzer 6.7.0
+- analyzer 6.7.0
 
 ## [6.0.0-beta.12]
 
-* another fix of `rawValue` retrieval
+- another fix of `rawValue` retrieval
 
 ## [6.0.0-beta.11]
 
-* fix `rawValue` retrieval
+- fix `rawValue` retrieval
 
 ## [6.0.0-beta.10]
 
-* equalsTo `value` => `rawValue`
+- equalsTo `value` => `rawValue`
 
 ## [6.0.0-beta.9]
 
-* equalsTo `mapEquals` => `DeepCollectionEquality`
+- equalsTo `mapEquals` => `DeepCollectionEquality`
 
 ## [6.0.0-beta.8]
 
-* equalsTo form => currentForm
+- equalsTo form => currentForm
 
 ## [6.0.0-beta.7]
 
-* equalsTo method
+- equalsTo method
 
 ## [6.0.0-beta.6]
 
-* improved logging
+- improved logging
 
 ## [6.0.0-beta.5]
 
-* improved logging
+- improved logging
 
 ## [6.0.0-beta.4]
 
-* improved logging
+- improved logging
 
 ## [6.0.0-beta.3]
 
-* InconsistentAnalysisException fix
+- InconsistentAnalysisException fix
 
 ## [6.0.0-beta.2]
 
-* InconsistentAnalysisException fix
+- InconsistentAnalysisException fix
 
 ## [6.0.0-beta.1]
 
-* BREAKING CHANGE: before generating code make sure to replace @Rf() with @Rf(output: false)
+- BREAKING CHANGE: before generating code make sure to replace @Rf() with
+  @Rf(output: false)
 
 ## [6.0.0-beta.0]
 
-* output
+- output
 
 ## [5.1.2]
 
-* ...ValueReset props pass through
+- ...ValueReset props pass through
 
 ## [5.1.1]
 
-* list control use `rawValue` instead of value
+- list control use `rawValue` instead of value
 
 ## [5.0.7]
 
-* equalsTo method
+- equalsTo method
 
 ## [5.0.6]
 
-* `[...]Controls` method for fetching typed array controls
+- `[...]Controls` method for fetching typed array controls
 
 ## [5.0.5]
 
-* https://github.com/artflutter/reactive_forms_generator/pull/169
+- https://github.com/artflutter/reactive_forms_generator/pull/169
 
 ## [5.0.3]
 
-* canPop and popInvoked fix
+- canPop and popInvoked fix
 
 ## [5.0.2]
 
-* build yaml extension fix
+- build yaml extension fix
 
 ## [5.0.1]
 
-* error type fix
+- error type fix
 
 ## [5.0.0]
 
-* rf17
+- rf17
 
 ## [4.8.0-beta.0]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/155
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/155
 
 ## [4.8.0]
 
-* toggleEnabled method added.
+- toggleEnabled method added.
 
 ## [4.6.0]
 
-* toggleEnabled method added.
+- toggleEnabled method added.
 
 ## [4.6.0-beta.2]
 
-* updated the error check method to prevent throwing useless stack traces
+- updated the error check method to prevent throwing useless stack traces
 
 ## [4.6.0-beta.1]
 
-* updated the error check method to prevent throwing useless stack traces
+- updated the error check method to prevent throwing useless stack traces
 
 ## [4.6.0-beta.0]
 
-* toggleEnabled method added.
+- toggleEnabled method added.
 
 ## [4.5.2]
 
-* default empty array value for non nullable lists
+- default empty array value for non nullable lists
 
 ## [4.5.1]
 
-* generate BuildContext extension for listening and watching the form
-* fix for cases with disabled fields for arrays, the disabled items were thrown off the `value`
-  which caused issues.
-* debugLog replaced with debugLogStackTrace for warnings when calling model on non-valid form
+- generate BuildContext extension for listening and watching the form
+- fix for cases with disabled fields for arrays, the disabled items were thrown
+  off the `value` which caused issues.
+- debugLog replaced with debugLogStackTrace for warnings when calling model on
+  non-valid form
 
 ## [4.5.0]
 
-* fix for cases with disabled fields for arrays, the disabled items were thrown off the `value`
-  which caused issues.
+- fix for cases with disabled fields for arrays, the disabled items were thrown
+  off the `value` which caused issues.
 
 ## [4.4.0]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/143
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/143
 
 ## [4.3.0]
 
-* currentForm getter
-* fix for submit method to take currentForm
+- currentForm getter
+- fix for submit method to take currentForm
 
 ## [4.2.0]
 
-* FormModel submit
+- FormModel submit
 
 ## [4.1.0]
 
-* improved generic form handling
+- improved generic form handling
 
 ## [4.0.2]
 
-* fix https://github.com/artflutter/reactive_forms_generator/issues/133
-* Allow upgrades to analyzer https://github.com/artflutter/reactive_forms_generator/pull/134
+- fix https://github.com/artflutter/reactive_forms_generator/issues/133
+- Allow upgrades to analyzer
+  https://github.com/artflutter/reactive_forms_generator/pull/134
 
 ## [4.0.1]
 
-* fix the add list item value parameter to nullability
+- fix the add list item value parameter to nullability
 
 ## [4.0.0]
 
-* annotation shorthands support - this is non-breaking change, old annotations will continue
-  working.
-  just a major bump for preventing unexpected auto updates
+- annotation shorthands support - this is non-breaking change, old annotations
+  will continue working. just a major bump for preventing unexpected auto
+  updates
 
 ## [3.0.1]
 
-* bugfix
+- bugfix
 
 ## [3.0.0]
 
-* rf 16 migration
+- rf 16 migration
 
 ## [2.0.1]
 
-* bugfix
+- bugfix
 
 ## [2.0.0]
 
-* rf 15 migration
+- rf 15 migration
 
 ## [1.2.0]
 
-* internal refactoring
-* all unannotated fields will be passes through the RF as simple controls
-* you can now skip ReactiveFormControl annotation if you do not need validators
-* annotateless form controls
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/112
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/110
+- internal refactoring
+- all unannotated fields will be passes through the RF as simple controls
+- you can now skip ReactiveFormControl annotation if you do not need validators
+- annotateless form controls
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/112
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/110
 
 ## [1.1.2-beta]
 
-* annotateless form controls
+- annotateless form controls
 
 ## [1.1.1-beta]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/112
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/112
 
 ## [1.1.0-beta]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/110
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/110
 
 ## [1.0.2]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/107
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/107
 
 ## [1.0.1]
 
-* make field names const
+- make field names const
 
 ## [1.0.0]
 
-* Internal refactoring. Everything should work as previously but there is a small chance of breaking
-  changes
+- Internal refactoring. Everything should work as previously but there is a
+  small chance of breaking changes
 
 ## [0.24.2-beta]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/88
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/88
 
 ## [0.24.1-beta]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/84
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/84
 
 ## [0.24.0-beta]
 
-* fixes and refactoring
+- fixes and refactoring
 
 ## [0.23.4]
 
-* bugfix for https://github.com/artflutter/reactive_forms_generator/issues/76
+- bugfix for https://github.com/artflutter/reactive_forms_generator/issues/76
 
 ## [0.23.3]
 
-* fix for positional unannotated fields
+- fix for positional unannotated fields
 
 ## [0.23.2]
 
-* didUpdateWidget for form builders
+- didUpdateWidget for form builders
 
 ## [0.23.1]
 
-* https://github.com/artflutter/reactive_forms_generator/issues/72
+- https://github.com/artflutter/reactive_forms_generator/issues/72
 
 ## [0.23.0]
 
-* release
+- release
 
 ## [0.23.0-beta]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/59
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/59
 
 ## [0.22.0-beta]
 
-* analyzer 5.2.0
+- analyzer 5.2.0
 
 ## [0.21.0-beta]
 
-* analyzer 5
+- analyzer 5
 
 ## [0.20.0-beta]
 
-* generics support
-* package update
+- generics support
+- package update
 
 ## [0.19.0-beta]
 
-* package update
+- package update
 
 ## [0.18.0-beta]
 
-* initState method for *FormBuilder class
-* *SetDisabled helper methods for all controls
-* *ControlValue accessors are private now because it is unsafe to call them on non valid form
-* added additional failsafe by falling back to default values on required fields which have default
-  value in model(for
-  strings only)
+- initState method for *FormBuilder class
+- *SetDisabled helper methods for all controls
+- *ControlValue accessors are private now because it is unsafe to call them on
+  non valid form
+- added additional failsafe by falling back to default values on required fields
+  which have default value in model(for strings only)
 
 ## [0.17.2-beta]
 
-* copyWithPath method to reduce `model` calls which could be unsafe on non valid form
+- copyWithPath method to reduce `model` calls which could be unsafe on non valid
+  form
 
 ## [0.17.1-beta]
 
-* dispose form
+- dispose form
 
 ## [0.17.0-beta]
 
-* update generator name for easier configuration in build.yaml
+- update generator name for easier configuration in build.yaml
 
 ## [0.16.0-beta]
 
-* typed validators for FormGroup
+- typed validators for FormGroup
 
 ## [0.15.0-beta]
 
-* bugfix: FormGroupAnnotation params were skipped
-* bugfix: updated initialization flow
+- bugfix: FormGroupAnnotation params were skipped
+- bugfix: updated initialization flow
 
 ## [0.14.1-beta]
 
-* bump dart version
+- bump dart version
 
 ## [0.14.0-beta]
 
-* Flutter 3
+- Flutter 3
 
 ## [0.13.0-beta]
 
-* replace ReactiveForm with ReactiveFormBuilder to avoid rebuilds and bugs
+- replace ReactiveForm with ReactiveFormBuilder to avoid rebuilds and bugs
 
 ## [0.12.1-beta]
 
-* never type support
+- never type support
 
 ## [0.12.0-beta]
 
-* typed form control annotation support
+- typed form control annotation support
 
 ## [0.11.0-beta]
 
-* widget for handling array of forms items see
-  packages/reactive_forms_generator/example/lib/docs/mailing_list/delivery_route_form.dart for
-  example of use
+- widget for handling array of forms items see
+  packages/reactive_forms_generator/example/lib/docs/mailing_list/delivery_route_form.dart
+  for example of use
 
 ## [0.10.0-beta]
 
-* widget for handling array of items see
-  packages/reactive_forms_generator/example/lib/docs/mailing_list/mailing_list_form.dart for example
-  of use
+- widget for handling array of items see
+  packages/reactive_forms_generator/example/lib/docs/mailing_list/mailing_list_form.dart
+  for example of use
 
 ## [0.9.8-beta]
 
-* bugfix
+- bugfix
 
 ## [0.9.7-beta]
 
-* ignore for file annotations
+- ignore for file annotations
 
 ## [0.9.6-beta]
 
-* model nullability control improvements and bugfixes
+- model nullability control improvements and bugfixes
 
 ## [0.9.5-beta]
 
-* array insert method
+- array insert method
 
 ## [0.9.4-beta]
 
-* bugfixes
+- bugfixes
 
 ## [0.9.3-beta]
 
-* bugfixes
-* array clear method
+- bugfixes
+- array clear method
 
 ## [0.9.2-beta]
 
-* bugfixes
+- bugfixes
 
 ## [0.9.1-beta]
 
-* more array helper methods
-* bugfixes(if you are working with arrays do not use form methods - use only generated one)
+- more array helper methods
+- bugfixes(if you are working with arrays do not use form methods - use only
+  generated one)
 
 ## [0.9.0-beta]
 
 **POSSIBLE BREAKING CHANGE**
 
-* experimenting with making model nullable for `*FormBuilder`
+- experimenting with making model nullable for `*FormBuilder`
 
 ## [0.8.0-beta]
 
-* analyzer 3+ support
+- analyzer 3+ support
 
 ## [0.7.0-beta]
 
-* contains and remove method refactored
+- contains and remove method refactored
 
 ## [0.6.1-beta]
 
-* FormModel interface
+- FormModel interface
 
 ## [0.6.0-beta]
 
-* subforms support
-* reactive-forms 11
+- subforms support
+- reactive-forms 11
 
 ## [0.5.0-beta]
 
-* package updates
+- package updates
 
 ## [0.4.0-beta]
 
 **BREAKING CHANGE**
 
-* made *.gform.dart a part file check README
-  file https://github.com/artflutter/reactive_forms_generator#run-the-generator
-* `const` constructors
+- made *.gform.dart a part file check README file
+  https://github.com/artflutter/reactive_forms_generator#run-the-generator
+- `const` constructors
 
 ## [0.3.2-beta]
 
-* [control]Remove methods
-* [control]ValueUpdate methods
-* [control]ValuePatch methods
-* [control]ValueReset methods
-* updateValue method
-* resetValue method
-* reset method
+- [control]Remove methods
+- [control]ValueUpdate methods
+- [control]ValuePatch methods
+- [control]ValueReset methods
+- updateValue method
+- resetValue method
+- reset method
 
 ## [0.3.1-beta]
 
-* fix for https://github.com/artflutter/reactive_forms_generator/issues/11
+- fix for https://github.com/artflutter/reactive_forms_generator/issues/11
 
 ## [0.3.0-beta]
 
-* package update
+- package update
 
 ## [0.2.2-beta]
 
-* removed redundant getters generated on non-annotated fields
+- removed redundant getters generated on non-annotated fields
 
 ## [0.2.1-beta]
 
-* fixed processing non annotated parameters
-* improved freezed support with private constructors
+- fixed processing non annotated parameters
+- improved freezed support with private constructors
 
 ## [0.2.0-beta]
 
-* analyzer 2.2.0 support
+- analyzer 2.2.0 support
 
 ## [0.1.1-beta]
 
-* generate method to add FormGroup item to array
+- generate method to add FormGroup item to array
 
 ## [0.1.0-beta]
 
 **BREAKING CHANGE**
 
-* repositioning of annotations
-* Freezed support
+- repositioning of annotations
+- Freezed support
 
 ## [0.0.15-beta]
 
-* generate method to add item to array
+- generate method to add item to array
 
 ## [0.0.14-beta]
 
-* extended array of form groups support
-* bugfixes
+- extended array of form groups support
+- bugfixes
 
 ## [0.0.13-beta]
 
-* bugfixes for array support
-* bugfixes for form groups
+- bugfixes for array support
+- bugfixes for form groups
 
 ## [0.0.12-beta]
 
-* bugfixes for form groups
-* form group example
+- bugfixes for form groups
+- form group example
 
 ## [0.0.11-beta]
 
-* improved support of array types
+- improved support of array types
 
 ## [0.0.10-beta]
 
-* quick fix
+- quick fix
 
 ## [0.0.9-beta]
 
-* array of form groups support
+- array of form groups support
 
 ## [0.0.8-beta]
 
-* asyncDebounceTime and disable support
+- asyncDebounceTime and disable support
 
 ## [0.0.7-beta]
 
-* FormGroup support
+- FormGroup support
 
 ## [0.0.6-beta]
 
-* FormControl type fix
+- FormControl type fix
 
 ## [0.0.5-beta]
 
-* hardcoded value fix
+- hardcoded value fix
 
 ## [0.0.4-beta]
 
-* re-import imports from model
+- re-import imports from model
 
 ## [0.0.3-beta]
 
-* pascal case fix
+- pascal case fix
 
 ## [0.0.2-beta]
 
-* small fix
+- small fix
 
 ## [0.0.1-beta]
 
-* initial release.
+- initial release.

--- a/packages/reactive_forms_generator/example/lib/docs/animated_url_list/animated_url_list.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/animated_url_list/animated_url_list.gform.dart
@@ -54,7 +54,7 @@ class ReactiveAnimatedUrlListForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveAnimatedUrlListForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnimatedUrlListForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveAnimatedUrlListForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class AnimatedUrlListFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class AnimatedUrlListFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, AnimatedUrlListForm formModel, Widget? child)
@@ -206,11 +208,11 @@ class _AnimatedUrlListFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/animated_url_list/animated_url_list_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/animated_url_list/animated_url_list_output.gform.dart
@@ -54,7 +54,7 @@ class ReactiveAnimatedUrlLisOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveAnimatedUrlLisOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnimatedUrlLisOForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveAnimatedUrlLisOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class AnimatedUrlLisOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class AnimatedUrlLisOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, AnimatedUrlLisOForm formModel, Widget? child)
@@ -206,11 +208,11 @@ class _AnimatedUrlLisOFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/annotateless/annotateless.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/annotateless/annotateless.gform.dart
@@ -53,7 +53,7 @@ class ReactiveAnnotatelessForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveAnnotatelessForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnnotatelessForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveAnnotatelessForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class AnnotatelessFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class AnnotatelessFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, AnnotatelessForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _AnnotatelessFormBuilderState extends State<AnnotatelessFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/annotateless/annotateless_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/annotateless/annotateless_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveAnnotatelessOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveAnnotatelessOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static AnnotatelessOForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveAnnotatelessOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class AnnotatelessOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class AnnotatelessOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, AnnotatelessOForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _AnnotatelessOFormBuilderState extends State<AnnotatelessOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/array_nullable/array_nullable.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/array_nullable/array_nullable.gform.dart
@@ -53,7 +53,7 @@ class ReactiveArrayNullableForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveArrayNullableForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ArrayNullableForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveArrayNullableForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class ArrayNullableFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class ArrayNullableFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ArrayNullableForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _ArrayNullableFormBuilderState extends State<ArrayNullableFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/array_nullable/array_nullable_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/array_nullable/array_nullable_output.gform.dart
@@ -54,7 +54,7 @@ class ReactiveArrayNullableOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveArrayNullableOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ArrayNullableOForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveArrayNullableOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class ArrayNullableOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class ArrayNullableOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, ArrayNullableOForm formModel, Widget? child)
@@ -205,11 +207,11 @@ class _ArrayNullableOFormBuilderState extends State<ArrayNullableOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/create/create_output.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/create/create_output.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -201,6 +200,238 @@ class _$MSICreateCopyWithImpl<$Res> implements $MSICreateCopyWith<$Res> {
     return $AddressCopyWith<$Res>(_self.mailingAddress, (value) {
       return _then(_self.copyWith(mailingAddress: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [MSICreate].
+extension MSICreatePatterns on MSICreate {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_MSICreate value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreate() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_MSICreate value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreate():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_MSICreate value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreate() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String? id,
+            String? businessNumber,
+            List<String>? fileIds,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? name,
+            Address companyAddress,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email,
+            PrimaryContact primaryContact,
+            @RfControl<bool>() bool sameMailingAddressAsCompany,
+            Address mailingAddress,
+            @RfArray<AdminContactInformation>()
+            List<AdminContactInformation> admins)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreate() when $default != null:
+        return $default(
+            _that.id,
+            _that.businessNumber,
+            _that.fileIds,
+            _that.name,
+            _that.companyAddress,
+            _that.email,
+            _that.primaryContact,
+            _that.sameMailingAddressAsCompany,
+            _that.mailingAddress,
+            _that.admins);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String? id,
+            String? businessNumber,
+            List<String>? fileIds,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? name,
+            Address companyAddress,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email,
+            PrimaryContact primaryContact,
+            @RfControl<bool>() bool sameMailingAddressAsCompany,
+            Address mailingAddress,
+            @RfArray<AdminContactInformation>()
+            List<AdminContactInformation> admins)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreate():
+        return $default(
+            _that.id,
+            _that.businessNumber,
+            _that.fileIds,
+            _that.name,
+            _that.companyAddress,
+            _that.email,
+            _that.primaryContact,
+            _that.sameMailingAddressAsCompany,
+            _that.mailingAddress,
+            _that.admins);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String? id,
+            String? businessNumber,
+            List<String>? fileIds,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? name,
+            Address companyAddress,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email,
+            PrimaryContact primaryContact,
+            @RfControl<bool>() bool sameMailingAddressAsCompany,
+            Address mailingAddress,
+            @RfArray<AdminContactInformation>()
+            List<AdminContactInformation> admins)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreate() when $default != null:
+        return $default(
+            _that.id,
+            _that.businessNumber,
+            _that.fileIds,
+            _that.name,
+            _that.companyAddress,
+            _that.email,
+            _that.primaryContact,
+            _that.sameMailingAddressAsCompany,
+            _that.mailingAddress,
+            _that.admins);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -543,6 +774,199 @@ class _$AddressCopyWithImpl<$Res> implements $AddressCopyWith<$Res> {
   }
 }
 
+/// Adds pattern-matching-related methods to [Address].
+extension AddressPatterns on Address {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Address value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Address() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Address value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Address():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Address value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Address() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? street,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? city,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? stateOrProvince,
+            @RfControl(validators: [RequiredValidator()]) String? zipCode)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Address() when $default != null:
+        return $default(
+            _that.street, _that.city, _that.stateOrProvince, _that.zipCode);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? street,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? city,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? stateOrProvince,
+            @RfControl(validators: [RequiredValidator()]) String? zipCode)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Address():
+        return $default(
+            _that.street, _that.city, _that.stateOrProvince, _that.zipCode);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? street,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? city,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? stateOrProvince,
+            @RfControl(validators: [RequiredValidator()]) String? zipCode)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Address() when $default != null:
+        return $default(
+            _that.street, _that.city, _that.stateOrProvince, _that.zipCode);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _Address implements Address {
@@ -738,6 +1162,184 @@ class _$PrimaryContactCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [PrimaryContact].
+extension PrimaryContactPatterns on PrimaryContact {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PrimaryContact value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContact() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PrimaryContact value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContact():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_PrimaryContact value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContact() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? fullName,
+            @RfControl(validators: [MaxLengthValidator(120)]) String? jobTitle,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContact() when $default != null:
+        return $default(_that.fullName, _that.jobTitle, _that.email);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? fullName,
+            @RfControl(validators: [MaxLengthValidator(120)]) String? jobTitle,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContact():
+        return $default(_that.fullName, _that.jobTitle, _that.email);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? fullName,
+            @RfControl(validators: [MaxLengthValidator(120)]) String? jobTitle,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContact() when $default != null:
+        return $default(_that.fullName, _that.jobTitle, _that.email);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _PrimaryContact implements PrimaryContact {
@@ -921,6 +1523,190 @@ class _$AdminContactInformationCopyWithImpl<$Res>
           : email // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AdminContactInformation].
+extension AdminContactInformationPatterns on AdminContactInformation {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AdminContactInformation value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformation() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AdminContactInformation value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformation():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AdminContactInformation value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformation() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? firstName,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? lastName,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformation() when $default != null:
+        return $default(_that.firstName, _that.lastName, _that.email);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? firstName,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? lastName,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformation():
+        return $default(_that.firstName, _that.lastName, _that.email);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? firstName,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String? lastName,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String? email)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformation() when $default != null:
+        return $default(_that.firstName, _that.lastName, _that.email);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1217,6 +2003,238 @@ class _$MSICreateOutputCopyWithImpl<$Res>
     return $AddressOutputCopyWith<$Res>(_self.mailingAddress, (value) {
       return _then(_self.copyWith(mailingAddress: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [MSICreateOutput].
+extension MSICreateOutputPatterns on MSICreateOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_MSICreateOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreateOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_MSICreateOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreateOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_MSICreateOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreateOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String? id,
+            String? businessNumber,
+            List<String>? fileIds,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String name,
+            AddressOutput companyAddress,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email,
+            PrimaryContactOutput primaryContact,
+            @RfControl<bool>() bool sameMailingAddressAsCompany,
+            AddressOutput mailingAddress,
+            @RfArray<AdminContactInformationOutput>()
+            List<AdminContactInformationOutput> admins)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreateOutput() when $default != null:
+        return $default(
+            _that.id,
+            _that.businessNumber,
+            _that.fileIds,
+            _that.name,
+            _that.companyAddress,
+            _that.email,
+            _that.primaryContact,
+            _that.sameMailingAddressAsCompany,
+            _that.mailingAddress,
+            _that.admins);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String? id,
+            String? businessNumber,
+            List<String>? fileIds,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String name,
+            AddressOutput companyAddress,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email,
+            PrimaryContactOutput primaryContact,
+            @RfControl<bool>() bool sameMailingAddressAsCompany,
+            AddressOutput mailingAddress,
+            @RfArray<AdminContactInformationOutput>()
+            List<AdminContactInformationOutput> admins)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreateOutput():
+        return $default(
+            _that.id,
+            _that.businessNumber,
+            _that.fileIds,
+            _that.name,
+            _that.companyAddress,
+            _that.email,
+            _that.primaryContact,
+            _that.sameMailingAddressAsCompany,
+            _that.mailingAddress,
+            _that.admins);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String? id,
+            String? businessNumber,
+            List<String>? fileIds,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String name,
+            AddressOutput companyAddress,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email,
+            PrimaryContactOutput primaryContact,
+            @RfControl<bool>() bool sameMailingAddressAsCompany,
+            AddressOutput mailingAddress,
+            @RfArray<AdminContactInformationOutput>()
+            List<AdminContactInformationOutput> admins)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MSICreateOutput() when $default != null:
+        return $default(
+            _that.id,
+            _that.businessNumber,
+            _that.fileIds,
+            _that.name,
+            _that.companyAddress,
+            _that.email,
+            _that.primaryContact,
+            _that.sameMailingAddressAsCompany,
+            _that.mailingAddress,
+            _that.admins);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1557,6 +2575,199 @@ class _$AddressOutputCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [AddressOutput].
+extension AddressOutputPatterns on AddressOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AddressOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AddressOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AddressOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AddressOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AddressOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AddressOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String street,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String city,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String stateOrProvince,
+            @RfControl(validators: [RequiredValidator()]) String zipCode)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AddressOutput() when $default != null:
+        return $default(
+            _that.street, _that.city, _that.stateOrProvince, _that.zipCode);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String street,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String city,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String stateOrProvince,
+            @RfControl(validators: [RequiredValidator()]) String zipCode)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AddressOutput():
+        return $default(
+            _that.street, _that.city, _that.stateOrProvince, _that.zipCode);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String street,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String city,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String stateOrProvince,
+            @RfControl(validators: [RequiredValidator()]) String zipCode)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AddressOutput() when $default != null:
+        return $default(
+            _that.street, _that.city, _that.stateOrProvince, _that.zipCode);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _AddressOutput implements AddressOutput {
@@ -1755,6 +2966,184 @@ class _$PrimaryContactOutputCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [PrimaryContactOutput].
+extension PrimaryContactOutputPatterns on PrimaryContactOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PrimaryContactOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContactOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PrimaryContactOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContactOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_PrimaryContactOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContactOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String fullName,
+            @RfControl(validators: [MaxLengthValidator(120)]) String? jobTitle,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContactOutput() when $default != null:
+        return $default(_that.fullName, _that.jobTitle, _that.email);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String fullName,
+            @RfControl(validators: [MaxLengthValidator(120)]) String? jobTitle,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContactOutput():
+        return $default(_that.fullName, _that.jobTitle, _that.email);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String fullName,
+            @RfControl(validators: [MaxLengthValidator(120)]) String? jobTitle,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PrimaryContactOutput() when $default != null:
+        return $default(_that.fullName, _that.jobTitle, _that.email);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _PrimaryContactOutput implements PrimaryContactOutput {
@@ -1941,6 +3330,191 @@ class _$AdminContactInformationOutputCopyWithImpl<$Res>
           : email // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AdminContactInformationOutput].
+extension AdminContactInformationOutputPatterns
+    on AdminContactInformationOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AdminContactInformationOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformationOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AdminContactInformationOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformationOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AdminContactInformationOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformationOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String firstName,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String lastName,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformationOutput() when $default != null:
+        return $default(_that.firstName, _that.lastName, _that.email);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String firstName,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String lastName,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformationOutput():
+        return $default(_that.firstName, _that.lastName, _that.email);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String firstName,
+            @RfControl(
+                validators: [RequiredValidator(), MaxLengthValidator(120)])
+            String lastName,
+            @RfControl(validators: [RequiredValidator(), EmailValidator()])
+            String email)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AdminContactInformationOutput() when $default != null:
+        return $default(_that.firstName, _that.lastName, _that.email);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/create/create_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/create/create_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveMSICreateForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveMSICreateForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static MSICreateForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveMSICreateForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -108,7 +109,7 @@ class MSICreateFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -119,7 +120,8 @@ class MSICreateFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, MSICreateForm formModel, Widget? child) builder;
@@ -198,11 +200,11 @@ class _MSICreateFormBuilderState extends State<MSICreateFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/delivery_list/delivery_list.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/delivery_list/delivery_list.gform.dart
@@ -53,7 +53,7 @@ class ReactiveDeliveryListForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveDeliveryListForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static DeliveryListForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveDeliveryListForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class DeliveryListFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class DeliveryListFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, DeliveryListForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _DeliveryListFormBuilderState extends State<DeliveryListFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -2131,7 +2133,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -2140,7 +2142,8 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StandaloneDeliveryPointForm? of(
     BuildContext context, {
@@ -2167,7 +2170,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -2188,7 +2191,7 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -2199,7 +2202,8 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       StandaloneDeliveryPointForm formModel, Widget? child) builder;
@@ -2283,11 +2287,11 @@ class _StandaloneDeliveryPointFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/delivery_list/delivery_list_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/delivery_list/delivery_list_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveDeliveryListOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveDeliveryListOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static DeliveryListOForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveDeliveryListOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class DeliveryListOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class DeliveryListOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, DeliveryListOForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _DeliveryListOFormBuilderState extends State<DeliveryListOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -2185,7 +2187,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -2194,7 +2196,8 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StandaloneDeliveryPointForm? of(
     BuildContext context, {
@@ -2221,7 +2224,7 @@ class ReactiveStandaloneDeliveryPointForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -2242,7 +2245,7 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -2253,7 +2256,8 @@ class StandaloneDeliveryPointFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       StandaloneDeliveryPointForm formModel, Widget? child) builder;
@@ -2337,11 +2341,11 @@ class _StandaloneDeliveryPointFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -125,6 +124,187 @@ class _$FreezedClassCopyWithImpl<$Res> implements $FreezedClassCopyWith<$Res> {
           : selectedSpaces // ignore: cast_nullable_to_non_nullable
               as List<String>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [FreezedClass].
+extension FreezedClassPatterns on FreezedClass {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_FreezedClass value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClass() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_FreezedClass value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClass():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_FreezedClass value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClass() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String? id,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClass() when $default != null:
+        return $default(_that.gender, _that.id, _that.name, _that.logoImage,
+            _that.year, _that.selectedSpaces);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String? id,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClass():
+        return $default(_that.gender, _that.id, _that.name, _that.logoImage,
+            _that.year, _that.selectedSpaces);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String? id,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClass() when $default != null:
+        return $default(_that.gender, _that.id, _that.name, _that.logoImage,
+            _that.year, _that.selectedSpaces);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class.gform.dart
@@ -53,7 +53,7 @@ class ReactiveFreezedClassForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveFreezedClassForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static FreezedClassForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveFreezedClassForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class FreezedClassFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class FreezedClassFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, FreezedClassForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _FreezedClassFormBuilderState extends State<FreezedClassFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class_output.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class_output.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -162,6 +161,220 @@ class _$FreezedClassOCopyWithImpl<$Res>
           : selectedSpaces // ignore: cast_nullable_to_non_nullable
               as List<String>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [FreezedClassO].
+extension FreezedClassOPatterns on FreezedClassO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_FreezedClassO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_FreezedClassO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_FreezedClassO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String? genderR,
+            @RfControl() String? id,
+            @RfControl(validators: [RequiredValidator()]) String? idR,
+            @RfControl(validators: [RequiredValidator()]) String idR2,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassO() when $default != null:
+        return $default(
+            _that.gender,
+            _that.genderR,
+            _that.id,
+            _that.idR,
+            _that.idR2,
+            _that.name,
+            _that.logoImage,
+            _that.year,
+            _that.selectedSpaces);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String? genderR,
+            @RfControl() String? id,
+            @RfControl(validators: [RequiredValidator()]) String? idR,
+            @RfControl(validators: [RequiredValidator()]) String idR2,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassO():
+        return $default(
+            _that.gender,
+            _that.genderR,
+            _that.id,
+            _that.idR,
+            _that.idR2,
+            _that.name,
+            _that.logoImage,
+            _that.year,
+            _that.selectedSpaces);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String? genderR,
+            @RfControl() String? id,
+            @RfControl(validators: [RequiredValidator()]) String? idR,
+            @RfControl(validators: [RequiredValidator()]) String idR2,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassO() when $default != null:
+        return $default(
+            _that.gender,
+            _that.genderR,
+            _that.id,
+            _that.idR,
+            _that.idR2,
+            _that.name,
+            _that.logoImage,
+            _that.year,
+            _that.selectedSpaces);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -503,6 +716,220 @@ class _$FreezedClassOOutputCopyWithImpl<$Res>
           : selectedSpaces // ignore: cast_nullable_to_non_nullable
               as List<String>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [FreezedClassOOutput].
+extension FreezedClassOOutputPatterns on FreezedClassOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_FreezedClassOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_FreezedClassOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_FreezedClassOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String genderR,
+            @RfControl() String? id,
+            @RfControl(validators: [RequiredValidator()]) String idR,
+            @RfControl(validators: [RequiredValidator()]) String idR2,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassOOutput() when $default != null:
+        return $default(
+            _that.gender,
+            _that.genderR,
+            _that.id,
+            _that.idR,
+            _that.idR2,
+            _that.name,
+            _that.logoImage,
+            _that.year,
+            _that.selectedSpaces);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String genderR,
+            @RfControl() String? id,
+            @RfControl(validators: [RequiredValidator()]) String idR,
+            @RfControl(validators: [RequiredValidator()]) String idR2,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassOOutput():
+        return $default(
+            _that.gender,
+            _that.genderR,
+            _that.id,
+            _that.idR,
+            _that.idR2,
+            _that.name,
+            _that.logoImage,
+            _that.year,
+            _that.selectedSpaces);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<String>() String? gender,
+            @RfControl(validators: [RequiredValidator()]) String genderR,
+            @RfControl() String? id,
+            @RfControl(validators: [RequiredValidator()]) String idR,
+            @RfControl(validators: [RequiredValidator()]) String idR2,
+            @RfControl<String>() String? name,
+            @JsonKey(name: 'logo_image') @RfControl<String>() String? logoImage,
+            @RfControl<double>() double? year,
+            List<String> selectedSpaces)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _FreezedClassOOutput() when $default != null:
+        return $default(
+            _that.gender,
+            _that.genderR,
+            _that.id,
+            _that.idR,
+            _that.idR2,
+            _that.name,
+            _that.logoImage,
+            _that.year,
+            _that.selectedSpaces);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed/freezed_class_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveFreezedClassOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveFreezedClassOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static FreezedClassOForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveFreezedClassOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class FreezedClassOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class FreezedClassOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, FreezedClassOForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _FreezedClassOFormBuilderState extends State<FreezedClassOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/freezed2/test.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed2/test.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -81,6 +80,169 @@ class _$TestCopyWithImpl<$Res> implements $TestCopyWith<$Res> {
           : description // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Test].
+extension TestPatterns on Test {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Test value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Test() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Test value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Test():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Test value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Test() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl<String>() String title,
+            @RfControl<String>() String? description)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Test() when $default != null:
+        return $default(_that.title, _that.description);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl<String>() String title,
+            @RfControl<String>() String? description)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Test():
+        return $default(_that.title, _that.description);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl<String>() String title,
+            @RfControl<String>() String? description)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Test() when $default != null:
+        return $default(_that.title, _that.description);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/freezed2/test.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/freezed2/test.gform.dart
@@ -53,7 +53,7 @@ class ReactiveTestForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveTestForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static TestForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveTestForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class TestFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class TestFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context, TestForm formModel, Widget? child)
       builder;
@@ -197,11 +199,11 @@ class _TestFormBuilderState extends State<TestFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/generic/generic.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/generic/generic.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -71,6 +70,163 @@ class _$TagsCopyWithImpl<T, $Res> implements $TagsCopyWith<T, $Res> {
           : tags // ignore: cast_nullable_to_non_nullable
               as List<T>?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Tags].
+extension TagsPatterns<T> on Tags<T> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Tags<T> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Tags() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Tags<T> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tags():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Tags<T> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tags() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() List<T>? tags)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Tags() when $default != null:
+        return $default(_that.tags);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() List<T>? tags) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tags():
+        return $default(_that.tags);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() List<T>? tags)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tags() when $default != null:
+        return $default(_that.tags);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/generic/generic.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/generic/generic.gform.dart
@@ -53,7 +53,7 @@ class ReactiveTagsForm<T> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveTagsForm<T> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static TagsForm<T>? of<T>(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveTagsForm<T> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class TagsFormBuilder<T> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class TagsFormBuilder<T> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, TagsForm<T> formModel, Widget? child) builder;
@@ -197,11 +199,11 @@ class _TagsFormBuilderState<T> extends State<TagsFormBuilder<T>> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/generic/generic_output.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/generic/generic_output.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -71,6 +70,163 @@ class _$TagsOCopyWithImpl<T, $Res> implements $TagsOCopyWith<T, $Res> {
           : tags // ignore: cast_nullable_to_non_nullable
               as List<T>?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [TagsO].
+extension TagsOPatterns<T> on TagsO<T> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_TagsO<T> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TagsO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_TagsO<T> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_TagsO<T> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() List<T>? tags)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TagsO() when $default != null:
+        return $default(_that.tags);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() List<T>? tags) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsO():
+        return $default(_that.tags);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() List<T>? tags)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsO() when $default != null:
+        return $default(_that.tags);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -212,6 +368,163 @@ class _$TagsOOutputCopyWithImpl<T, $Res>
           : tags // ignore: cast_nullable_to_non_nullable
               as List<T>?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [TagsOOutput].
+extension TagsOOutputPatterns<T> on TagsOOutput<T> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_TagsOOutput<T> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TagsOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_TagsOOutput<T> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_TagsOOutput<T> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() List<T>? tags)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TagsOOutput() when $default != null:
+        return $default(_that.tags);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() List<T>? tags) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsOOutput():
+        return $default(_that.tags);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() List<T>? tags)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TagsOOutput() when $default != null:
+        return $default(_that.tags);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/generic/generic_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/generic/generic_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveTagsOForm<T> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveTagsOForm<T> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static TagsOForm<T>? of<T>(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveTagsOForm<T> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -108,7 +109,7 @@ class TagsOFormBuilder<T> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -119,7 +120,8 @@ class TagsOFormBuilder<T> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, TagsOForm<T> formModel, Widget? child) builder;
@@ -198,11 +200,11 @@ class _TagsOFormBuilderState<T> extends State<TagsOFormBuilder<T>> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/generic_status_list/generic_status_list.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/generic_status_list/generic_status_list.gform.dart
@@ -54,7 +54,7 @@ class ReactiveStatusListForm<T extends Enum> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveStatusListForm<T extends Enum> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StatusListForm<T>? of<T extends Enum>(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveStatusListForm<T extends Enum> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class StatusListFormBuilder<T extends Enum> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class StatusListFormBuilder<T extends Enum> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, StatusListForm<T> formModel, Widget? child) builder;
@@ -205,11 +207,11 @@ class _StatusListFormBuilderState<T extends Enum>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/generic_status_list/generic_status_list_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/generic_status_list/generic_status_list_output.gform.dart
@@ -55,7 +55,7 @@ class ReactiveStatusListOForm<T extends Enum> extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -64,7 +64,8 @@ class ReactiveStatusListOForm<T extends Enum> extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static StatusListOForm<T>? of<T extends Enum>(
     BuildContext context, {
@@ -91,7 +92,7 @@ class ReactiveStatusListOForm<T extends Enum> extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -112,7 +113,7 @@ class StatusListOFormBuilder<T extends Enum> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -123,7 +124,8 @@ class StatusListOFormBuilder<T extends Enum> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, StatusListOForm<T> formModel, Widget? child)
@@ -207,11 +209,11 @@ class _StatusListOFormBuilderState<T extends Enum>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/group/group.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/group/group.gform.dart
@@ -53,7 +53,7 @@ class ReactiveGroupForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveGroupForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveGroupForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class GroupFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class GroupFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupForm formModel, Widget? child) builder;
@@ -197,11 +199,11 @@ class _GroupFormBuilderState extends State<GroupFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/group/group_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/group/group_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveGroupOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveGroupOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupOForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveGroupOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class GroupOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class GroupOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupOForm formModel, Widget? child) builder;
@@ -197,11 +199,11 @@ class _GroupOFormBuilderState extends State<GroupOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/login/login.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login/login.gform.dart
@@ -53,7 +53,7 @@ class ReactiveLoginForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveLoginForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveLoginForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class LoginFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class LoginFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, LoginForm formModel, Widget? child) builder;
@@ -197,11 +199,11 @@ class _LoginFormBuilderState extends State<LoginFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/login/login_form.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login/login_form.dart
@@ -23,7 +23,7 @@ class _LoginFormWidgetState extends State<LoginFormWidget> {
       title: const Text('Login'),
       body: LoginFormBuilder(
         canPop: (formGroup) => true,
-        onPopInvoked: (formGroup, didPop) => {},
+        onPopInvokedWithResult: (formGroup, didPop, result) => {},
         model: _emptyModel,
         builder: (context, formModel, child) {
           return Column(

--- a/packages/reactive_forms_generator/example/lib/docs/login/login_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login/login_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveLoginOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveLoginOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginOForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveLoginOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class LoginOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class LoginOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, LoginOForm formModel, Widget? child) builder;
@@ -197,11 +199,11 @@ class _LoginOFormBuilderState extends State<LoginOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/login_extended/login_extended.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login_extended/login_extended.gform.dart
@@ -53,7 +53,7 @@ class ReactiveLoginExtendedForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveLoginExtendedForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveLoginExtendedForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class LoginExtendedFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class LoginExtendedFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, LoginExtendedForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _LoginExtendedFormBuilderState extends State<LoginExtendedFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/login_extended/login_extended_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login_extended/login_extended_output.gform.dart
@@ -54,7 +54,7 @@ class ReactiveLoginExtendedOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveLoginExtendedOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedOForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveLoginExtendedOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class LoginExtendedOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class LoginExtendedOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, LoginExtendedOForm formModel, Widget? child)
@@ -205,11 +207,11 @@ class _LoginExtendedOFormBuilderState extends State<LoginExtendedOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/login_extended_nullable/login_extended_nullable.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login_extended_nullable/login_extended_nullable.gform.dart
@@ -54,7 +54,7 @@ class ReactiveLoginExtendedNullableForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveLoginExtendedNullableForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedNullableForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveLoginExtendedNullableForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class LoginExtendedNullableFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class LoginExtendedNullableFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       LoginExtendedNullableForm formModel, Widget? child) builder;
@@ -206,11 +208,11 @@ class _LoginExtendedNullableFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/login_extended_nullable/login_extended_nullable_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/login_extended_nullable/login_extended_nullable_output.gform.dart
@@ -54,7 +54,7 @@ class ReactiveLoginExtendedNullableOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveLoginExtendedNullableOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static LoginExtendedNullableOForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveLoginExtendedNullableOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class LoginExtendedNullableOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class LoginExtendedNullableOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       LoginExtendedNullableOForm formModel, Widget? child) builder;
@@ -206,11 +208,11 @@ class _LoginExtendedNullableOFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/mailing_list/mailing_list.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/mailing_list/mailing_list.gform.dart
@@ -53,7 +53,7 @@ class ReactiveMailingListForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveMailingListForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static MailingListForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveMailingListForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -109,7 +110,7 @@ class MailingListFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -120,7 +121,8 @@ class MailingListFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, MailingListForm formModel, Widget? child) builder;
@@ -201,11 +203,11 @@ class _MailingListFormBuilderState extends State<MailingListFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/mailing_list/mailing_list_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/mailing_list/mailing_list_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveMailingListOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveMailingListOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static MailingListOForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveMailingListOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class MailingListOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class MailingListOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, MailingListOForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _MailingListOFormBuilderState extends State<MailingListOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/model_extends/model_extends.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/model_extends/model_extends.gform.dart
@@ -53,7 +53,7 @@ class ReactiveModelExtendsForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveModelExtendsForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ModelExtendsForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveModelExtendsForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class ModelExtendsFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class ModelExtendsFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ModelExtendsForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _ModelExtendsFormBuilderState extends State<ModelExtendsFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/model_implements/model_implements.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/model_implements/model_implements.gform.dart
@@ -54,7 +54,7 @@ class ReactiveModelImplementsForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -63,7 +63,8 @@ class ReactiveModelImplementsForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ModelImplementsForm? of(
     BuildContext context, {
@@ -90,7 +91,7 @@ class ReactiveModelImplementsForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -111,7 +112,7 @@ class ModelImplementsFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -122,7 +123,8 @@ class ModelImplementsFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
           BuildContext context, ModelImplementsForm formModel, Widget? child)
@@ -206,11 +208,11 @@ class _ModelImplementsFormBuilderState
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/nested/nested.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested/nested.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,163 @@ class _$SubGroupCopyWithImpl<$Res> implements $SubGroupCopyWith<$Res> {
           : id // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [SubGroup].
+extension SubGroupPatterns on SubGroup {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SubGroup value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroup() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SubGroup value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroup():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SubGroup value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroup() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String id)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroup() when $default != null:
+        return $default(_that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String id) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroup():
+        return $default(_that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String id)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroup() when $default != null:
+        return $default(_that.id);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -227,6 +383,169 @@ class _$GroupCopyWithImpl<$Res> implements $GroupCopyWith<$Res> {
           : subGroupList // ignore: cast_nullable_to_non_nullable
               as List<SubGroup>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Group].
+extension GroupPatterns on Group {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Group value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Group() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Group value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Group():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Group value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Group() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroup> subGroupList)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Group() when $default != null:
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroup> subGroupList)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Group():
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroup> subGroupList)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Group() when $default != null:
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -388,6 +707,163 @@ class _$NestedCopyWithImpl<$Res> implements $NestedCopyWith<$Res> {
           : groupList // ignore: cast_nullable_to_non_nullable
               as List<Group>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Nested].
+extension NestedPatterns on Nested {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Nested value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Nested() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Nested value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Nested():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Nested value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Nested() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfArray<dynamic>() List<Group> groupList)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Nested() when $default != null:
+        return $default(_that.groupList);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfArray<dynamic>() List<Group> groupList) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Nested():
+        return $default(_that.groupList);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfArray<dynamic>() List<Group> groupList)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Nested() when $default != null:
+        return $default(_that.groupList);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/nested/nested.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested/nested.gform.dart
@@ -53,7 +53,7 @@ class ReactiveSubGroupForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveSubGroupForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SubGroupForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveSubGroupForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -108,7 +109,7 @@ class SubGroupFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -119,7 +120,8 @@ class SubGroupFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SubGroupForm formModel, Widget? child) builder;
@@ -198,11 +200,11 @@ class _SubGroupFormBuilderState extends State<SubGroupFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -681,7 +683,7 @@ class ReactiveGroupForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -690,7 +692,8 @@ class ReactiveGroupForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupForm? of(
     BuildContext context, {
@@ -716,7 +719,7 @@ class ReactiveGroupForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -735,7 +738,7 @@ class GroupFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -746,7 +749,8 @@ class GroupFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupForm formModel, Widget? child) builder;
@@ -825,11 +829,11 @@ class _GroupFormBuilderState extends State<GroupFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1503,7 +1507,7 @@ class ReactiveNestedForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1512,7 +1516,8 @@ class ReactiveNestedForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static NestedForm? of(
     BuildContext context, {
@@ -1538,7 +1543,7 @@ class ReactiveNestedForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1557,7 +1562,7 @@ class NestedFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1568,7 +1573,8 @@ class NestedFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, NestedForm formModel, Widget? child) builder;
@@ -1647,11 +1653,11 @@ class _NestedFormBuilderState extends State<NestedFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/nested/nested_output.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested/nested_output.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,163 @@ class _$SubGroupOCopyWithImpl<$Res> implements $SubGroupOCopyWith<$Res> {
           : id // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [SubGroupO].
+extension SubGroupOPatterns on SubGroupO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SubGroupO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SubGroupO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SubGroupO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String id)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupO() when $default != null:
+        return $default(_that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String id) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupO():
+        return $default(_that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String id)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupO() when $default != null:
+        return $default(_that.id);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -228,6 +384,169 @@ class _$GroupOCopyWithImpl<$Res> implements $GroupOCopyWith<$Res> {
           : subGroupList // ignore: cast_nullable_to_non_nullable
               as List<SubGroupO>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [GroupO].
+extension GroupOPatterns on GroupO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_GroupO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _GroupO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_GroupO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_GroupO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroupO> subGroupList)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _GroupO() when $default != null:
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroupO> subGroupList)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupO():
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroupO> subGroupList)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupO() when $default != null:
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -392,6 +711,163 @@ class _$NestedOCopyWithImpl<$Res> implements $NestedOCopyWith<$Res> {
   }
 }
 
+/// Adds pattern-matching-related methods to [NestedO].
+extension NestedOPatterns on NestedO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_NestedO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _NestedO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_NestedO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_NestedO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfArray<dynamic>() List<GroupO> groupList)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _NestedO() when $default != null:
+        return $default(_that.groupList);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfArray<dynamic>() List<GroupO> groupList) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedO():
+        return $default(_that.groupList);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfArray<dynamic>() List<GroupO> groupList)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedO() when $default != null:
+        return $default(_that.groupList);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
 class _NestedO implements NestedO {
@@ -540,6 +1016,163 @@ class _$SubGroupOOutputCopyWithImpl<$Res>
           : id // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [SubGroupOOutput].
+extension SubGroupOOutputPatterns on SubGroupOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SubGroupOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SubGroupOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SubGroupOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String id)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupOOutput() when $default != null:
+        return $default(_that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String id) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupOOutput():
+        return $default(_that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String id)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SubGroupOOutput() when $default != null:
+        return $default(_that.id);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -697,6 +1330,169 @@ class _$GroupOOutputCopyWithImpl<$Res> implements $GroupOOutputCopyWith<$Res> {
           : subGroupList // ignore: cast_nullable_to_non_nullable
               as List<SubGroupOOutput>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [GroupOOutput].
+extension GroupOOutputPatterns on GroupOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_GroupOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _GroupOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_GroupOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_GroupOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroupOOutput> subGroupList)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _GroupOOutput() when $default != null:
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroupOOutput> subGroupList)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupOOutput():
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String id,
+            @RfArray<dynamic>() List<SubGroupOOutput> subGroupList)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _GroupOOutput() when $default != null:
+        return $default(_that.id, _that.subGroupList);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -865,6 +1661,165 @@ class _$NestedOOutputCopyWithImpl<$Res>
           : groupList // ignore: cast_nullable_to_non_nullable
               as List<GroupOOutput>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [NestedOOutput].
+extension NestedOOutputPatterns on NestedOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_NestedOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _NestedOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_NestedOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_NestedOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfArray<dynamic>() List<GroupOOutput> groupList)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _NestedOOutput() when $default != null:
+        return $default(_that.groupList);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfArray<dynamic>() List<GroupOOutput> groupList) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedOOutput():
+        return $default(_that.groupList);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfArray<dynamic>() List<GroupOOutput> groupList)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NestedOOutput() when $default != null:
+        return $default(_that.groupList);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/nested/nested_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested/nested_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveSubGroupOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveSubGroupOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SubGroupOForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveSubGroupOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -108,7 +109,7 @@ class SubGroupOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -119,7 +120,8 @@ class SubGroupOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SubGroupOForm formModel, Widget? child) builder;
@@ -198,11 +200,11 @@ class _SubGroupOFormBuilderState extends State<SubGroupOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -715,7 +717,7 @@ class ReactiveGroupOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -724,7 +726,8 @@ class ReactiveGroupOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static GroupOForm? of(
     BuildContext context, {
@@ -750,7 +753,7 @@ class ReactiveGroupOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -769,7 +772,7 @@ class GroupOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -780,7 +783,8 @@ class GroupOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, GroupOForm formModel, Widget? child) builder;
@@ -859,11 +863,11 @@ class _GroupOFormBuilderState extends State<GroupOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1538,7 +1542,7 @@ class ReactiveNestedOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1547,7 +1551,8 @@ class ReactiveNestedOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static NestedOForm? of(
     BuildContext context, {
@@ -1573,7 +1578,7 @@ class ReactiveNestedOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1592,7 +1597,7 @@ class NestedOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1603,7 +1608,8 @@ class NestedOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, NestedOForm formModel, Widget? child) builder;
@@ -1682,11 +1688,11 @@ class _NestedOFormBuilderState extends State<NestedOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -99,6 +98,170 @@ class _$ProductDetailsCopyWithImpl<P extends Product, C extends Cart, $Res>
     return $IdCopyWith<P, C, $Res>(_self.id!, (value) {
       return _then(_self.copyWith(id: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ProductDetails].
+extension ProductDetailsPatterns<P extends Product, C extends Cart>
+    on ProductDetails<P, C> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ProductDetails<P, C> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetails() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ProductDetails<P, C> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetails():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ProductDetails<P, C> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetails() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? description, @Rf(output: false) Id<P, C>? id)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetails() when $default != null:
+        return $default(_that.description, _that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? description, @Rf(output: false) Id<P, C>? id)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetails():
+        return $default(_that.description, _that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl() String? description, @Rf(output: false) Id<P, C>? id)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetails() when $default != null:
+        return $default(_that.description, _that.id);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -272,6 +435,169 @@ class _$IdCopyWithImpl<P extends Product, C extends Cart, $Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [Id].
+extension IdPatterns<P extends Product, C extends Cart> on Id<P, C> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Id<P, C> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Id() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Id<P, C> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Id():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Id<P, C> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Id() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? companyName, @RfControl() String? name)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Id() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? companyName, @RfControl() String? name)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Id():
+        return $default(_that.companyName, _that.name);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl() String? companyName, @RfControl() String? name)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Id() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _Id<P extends Product, C extends Cart> extends Id<P, C> {
@@ -414,6 +740,163 @@ class _$ProductCopyWithImpl<$Res> implements $ProductCopyWith<$Res> {
           : name // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Product].
+extension ProductPatterns on Product {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Product value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Product value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Product value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? companyName, String? name)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? companyName, String? name) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product():
+        return $default(_that.companyName, _that.name);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? companyName, String? name)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -571,6 +1054,163 @@ class _$CartCopyWithImpl<$Res> implements $CartCopyWith<$Res> {
     return $ProductCopyWith<$Res>(_self.product!, (value) {
       return _then(_self.copyWith(product: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [Cart].
+extension CartPatterns on Cart {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Cart value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Cart value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Cart value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(Product? product, String? description)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that.product, _that.description);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(Product? product, String? description) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart():
+        return $default(_that.product, _that.description);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(Product? product, String? description)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that.product, _that.description);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics.gform.dart
@@ -56,7 +56,7 @@ class ReactiveProductDetailsForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -65,7 +65,8 @@ class ReactiveProductDetailsForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProductDetailsForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -92,7 +93,7 @@ class ReactiveProductDetailsForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -116,7 +117,7 @@ class ProductDetailsFormBuilder<P extends Product, C extends Cart>
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -127,7 +128,8 @@ class ProductDetailsFormBuilder<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       ProductDetailsForm<P, C> formModel, Widget? child) builder;
@@ -210,11 +212,11 @@ class _ProductDetailsFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1196,7 +1198,7 @@ class ReactiveIdForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1205,7 +1207,8 @@ class ReactiveIdForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static IdForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -1231,7 +1234,7 @@ class ReactiveIdForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1252,7 +1255,7 @@ class IdFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1263,7 +1266,8 @@ class IdFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, IdForm<P, C> formModel, Widget? child) builder;
@@ -1343,11 +1347,11 @@ class _IdFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics_output.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics_output.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -100,6 +99,170 @@ class _$ProductDetailsOCopyWithImpl<P extends Product, C extends Cart, $Res>
     return $IdOCopyWith<P, C, $Res>(_self.id!, (value) {
       return _then(_self.copyWith(id: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ProductDetailsO].
+extension ProductDetailsOPatterns<P extends Product, C extends Cart>
+    on ProductDetailsO<P, C> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ProductDetailsO<P, C> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ProductDetailsO<P, C> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ProductDetailsO<P, C> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? description, @Rf(output: false) IdO<P, C>? id)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsO() when $default != null:
+        return $default(_that.description, _that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? description, @Rf(output: false) IdO<P, C>? id)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsO():
+        return $default(_that.description, _that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl() String? description, @Rf(output: false) IdO<P, C>? id)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsO() when $default != null:
+        return $default(_that.description, _that.id);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -273,6 +436,169 @@ class _$IdOCopyWithImpl<P extends Product, C extends Cart, $Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [IdO].
+extension IdOPatterns<P extends Product, C extends Cart> on IdO<P, C> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_IdO<P, C> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IdO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_IdO<P, C> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_IdO<P, C> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? companyName, @RfControl() String? name)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IdO() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? companyName, @RfControl() String? name)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdO():
+        return $default(_that.companyName, _that.name);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl() String? companyName, @RfControl() String? name)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdO() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _IdO<P extends Product, C extends Cart> extends IdO<P, C> {
@@ -415,6 +741,163 @@ class _$ProductCopyWithImpl<$Res> implements $ProductCopyWith<$Res> {
           : name // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Product].
+extension ProductPatterns on Product {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Product value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Product value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Product value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? companyName, String? name)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? companyName, String? name) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product():
+        return $default(_that.companyName, _that.name);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? companyName, String? name)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Product() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -572,6 +1055,163 @@ class _$CartCopyWithImpl<$Res> implements $CartCopyWith<$Res> {
     return $ProductCopyWith<$Res>(_self.product!, (value) {
       return _then(_self.copyWith(product: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [Cart].
+extension CartPatterns on Cart {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Cart value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Cart value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Cart value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(Product? product, String? description)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that.product, _that.description);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(Product? product, String? description) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart():
+        return $default(_that.product, _that.description);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(Product? product, String? description)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Cart() when $default != null:
+        return $default(_that.product, _that.description);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -758,6 +1398,170 @@ class _$ProductDetailsOOutputCopyWithImpl<P extends Product, C extends Cart,
   }
 }
 
+/// Adds pattern-matching-related methods to [ProductDetailsOOutput].
+extension ProductDetailsOOutputPatterns<P extends Product, C extends Cart>
+    on ProductDetailsOOutput<P, C> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ProductDetailsOOutput<P, C> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ProductDetailsOOutput<P, C> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ProductDetailsOOutput<P, C> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@RfControl() String? description,
+            @Rf(output: false) IdOOutput<P, C>? id)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsOOutput() when $default != null:
+        return $default(_that.description, _that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@RfControl() String? description,
+            @Rf(output: false) IdOOutput<P, C>? id)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsOOutput():
+        return $default(_that.description, _that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@RfControl() String? description,
+            @Rf(output: false) IdOOutput<P, C>? id)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProductDetailsOOutput() when $default != null:
+        return $default(_that.description, _that.id);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _ProductDetailsOOutput<P extends Product, C extends Cart>
@@ -932,6 +1736,170 @@ class _$IdOOutputCopyWithImpl<P extends Product, C extends Cart, $Res>
           : name // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [IdOOutput].
+extension IdOOutputPatterns<P extends Product, C extends Cart>
+    on IdOOutput<P, C> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_IdOOutput<P, C> value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IdOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_IdOOutput<P, C> value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_IdOOutput<P, C> value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? companyName, @RfControl() String? name)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IdOOutput() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl() String? companyName, @RfControl() String? name)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdOOutput():
+        return $default(_that.companyName, _that.name);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl() String? companyName, @RfControl() String? name)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IdOOutput() when $default != null:
+        return $default(_that.companyName, _that.name);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/nested_generics/nested_generics_output.gform.dart
@@ -56,7 +56,7 @@ class ReactiveProductDetailsOForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -65,7 +65,8 @@ class ReactiveProductDetailsOForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProductDetailsOForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -92,7 +93,7 @@ class ReactiveProductDetailsOForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -116,7 +117,7 @@ class ProductDetailsOFormBuilder<P extends Product, C extends Cart>
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -127,7 +128,8 @@ class ProductDetailsOFormBuilder<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(BuildContext context,
       ProductDetailsOForm<P, C> formModel, Widget? child) builder;
@@ -210,11 +212,11 @@ class _ProductDetailsOFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,
@@ -1220,7 +1222,7 @@ class ReactiveIdOForm<P extends Product, C extends Cart>
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -1229,7 +1231,8 @@ class ReactiveIdOForm<P extends Product, C extends Cart>
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static IdOForm<P, C>? of<P extends Product, C extends Cart>(
     BuildContext context, {
@@ -1255,7 +1258,7 @@ class ReactiveIdOForm<P extends Product, C extends Cart>
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -1276,7 +1279,7 @@ class IdOFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -1287,7 +1290,8 @@ class IdOFormBuilder<P extends Product, C extends Cart> extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, IdOForm<P, C> formModel, Widget? child) builder;
@@ -1367,11 +1371,11 @@ class _IdOFormBuilderState<P extends Product, C extends Cart>
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/profile/profile.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/profile/profile.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -214,6 +213,226 @@ class _$ProfileCopyWithImpl<$Res> implements $ProfileCopyWith<$Res> {
     return $TimerSettingCopyWith<$Res>(_self.timer, (value) {
       return _then(_self.copyWith(timer: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [Profile].
+extension ProfilePatterns on Profile {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Profile value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Profile() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Profile value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Profile():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Profile value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Profile() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilter incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSetting threshold,
+            TimerSetting timer,
+            @RfControl<bool>() bool audioGuidance)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Profile() when $default != null:
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilter incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSetting threshold,
+            TimerSetting timer,
+            @RfControl<bool>() bool audioGuidance)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Profile():
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilter incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSetting threshold,
+            TimerSetting timer,
+            @RfControl<bool>() bool audioGuidance)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Profile() when $default != null:
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -532,6 +751,169 @@ class _$ThresholdSettingCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [ThresholdSetting].
+extension ThresholdSettingPatterns on ThresholdSetting {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ThresholdSetting value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSetting() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ThresholdSetting value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSetting():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ThresholdSetting value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSetting() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSetting() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSetting():
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSetting() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
 class _ThresholdSetting implements ThresholdSetting {
@@ -697,6 +1079,169 @@ class _$TimerSettingCopyWithImpl<$Res> implements $TimerSettingCopyWith<$Res> {
           : value // ignore: cast_nullable_to_non_nullable
               as int,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [TimerSetting].
+extension TimerSettingPatterns on TimerSetting {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_TimerSetting value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSetting() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_TimerSetting value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSetting():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_TimerSetting value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSetting() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSetting() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSetting():
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSetting() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -916,6 +1461,202 @@ class _$IncidenceFilterCopyWithImpl<$Res>
           : isPlaqueEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [IncidenceFilter].
+extension IncidenceFilterPatterns on IncidenceFilter {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_IncidenceFilter value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilter() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_IncidenceFilter value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilter():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_IncidenceFilter value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilter() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilter() when $default != null:
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilter():
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilter() when $default != null:
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1156,6 +1897,188 @@ class _$ScanOrderCopyWithImpl<$Res> implements $ScanOrderCopyWith<$Res> {
           : toothSide // ignore: cast_nullable_to_non_nullable
               as ToothSide,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ScanOrder].
+extension ScanOrderPatterns on ScanOrder {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ArchScanOrder value)? arch,
+    TResult Function(QuadrantScanOrder value)? quadrant,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ArchScanOrder value) arch,
+    required TResult Function(QuadrantScanOrder value) quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder():
+        return arch(_that);
+      case QuadrantScanOrder():
+        return quadrant(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ArchScanOrder value)? arch,
+    TResult? Function(QuadrantScanOrder value)? quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Jaw jaw, Direction direction, ToothSide toothSide)? arch,
+    TResult Function(
+            Quadrant quadrant, Direction direction, ToothSide toothSide)?
+        quadrant,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that.jaw, _that.direction, _that.toothSide);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that.quadrant, _that.direction, _that.toothSide);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Jaw jaw, Direction direction, ToothSide toothSide)
+        arch,
+    required TResult Function(
+            Quadrant quadrant, Direction direction, ToothSide toothSide)
+        quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder():
+        return arch(_that.jaw, _that.direction, _that.toothSide);
+      case QuadrantScanOrder():
+        return quadrant(_that.quadrant, _that.direction, _that.toothSide);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Jaw jaw, Direction direction, ToothSide toothSide)? arch,
+    TResult? Function(
+            Quadrant quadrant, Direction direction, ToothSide toothSide)?
+        quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that.jaw, _that.direction, _that.toothSide);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that.quadrant, _that.direction, _that.toothSide);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1443,6 +2366,169 @@ class _$ChartingOrderValueCopyWithImpl<$Res>
           : order // ignore: cast_nullable_to_non_nullable
               as List<List<ScanOrder>>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChartingOrderValue].
+extension ChartingOrderValuePatterns on ChartingOrderValue {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChartingOrderValue value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChartingOrderValue value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChartingOrderValue value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(ChartingOrderType chartingOrder, int selectedOption,
+            List<List<ScanOrder>> order)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that.chartingOrder, _that.selectedOption, _that.order);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(ChartingOrderType chartingOrder, int selectedOption,
+            List<List<ScanOrder>> order)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue():
+        return $default(_that.chartingOrder, _that.selectedOption, _that.order);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(ChartingOrderType chartingOrder, int selectedOption,
+            List<List<ScanOrder>> order)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that.chartingOrder, _that.selectedOption, _that.order);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/profile/profile.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/profile/profile.gform.dart
@@ -53,7 +53,7 @@ class ReactiveProfileForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveProfileForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProfileForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveProfileForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -107,7 +108,7 @@ class ProfileFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -118,7 +119,8 @@ class ProfileFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ProfileForm formModel, Widget? child) builder;
@@ -197,11 +199,11 @@ class _ProfileFormBuilderState extends State<ProfileFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/profile/profile_output.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/profile/profile_output.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -214,6 +213,226 @@ class _$ProfileOCopyWithImpl<$Res> implements $ProfileOCopyWith<$Res> {
     return $TimerSettingOCopyWith<$Res>(_self.timer, (value) {
       return _then(_self.copyWith(timer: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ProfileO].
+extension ProfileOPatterns on ProfileO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ProfileO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ProfileO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ProfileO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilterO incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSettingO threshold,
+            TimerSettingO timer,
+            @RfControl<bool>() bool audioGuidance)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileO() when $default != null:
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilterO incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSettingO threshold,
+            TimerSettingO timer,
+            @RfControl<bool>() bool audioGuidance)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileO():
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilterO incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSettingO threshold,
+            TimerSettingO timer,
+            @RfControl<bool>() bool audioGuidance)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileO() when $default != null:
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -533,6 +752,169 @@ class _$ThresholdSettingOCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [ThresholdSettingO].
+extension ThresholdSettingOPatterns on ThresholdSettingO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ThresholdSettingO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ThresholdSettingO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ThresholdSettingO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingO() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingO():
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingO() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
 class _ThresholdSettingO implements ThresholdSettingO {
@@ -699,6 +1081,169 @@ class _$TimerSettingOCopyWithImpl<$Res>
           : value // ignore: cast_nullable_to_non_nullable
               as int,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [TimerSettingO].
+extension TimerSettingOPatterns on TimerSettingO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_TimerSettingO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_TimerSettingO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_TimerSettingO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingO() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingO():
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingO() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -918,6 +1463,202 @@ class _$IncidenceFilterOCopyWithImpl<$Res>
           : isPlaqueEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [IncidenceFilterO].
+extension IncidenceFilterOPatterns on IncidenceFilterO {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_IncidenceFilterO value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterO() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_IncidenceFilterO value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterO():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_IncidenceFilterO value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterO() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterO() when $default != null:
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterO():
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterO() when $default != null:
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1158,6 +1899,188 @@ class _$ScanOrderCopyWithImpl<$Res> implements $ScanOrderCopyWith<$Res> {
           : toothSide // ignore: cast_nullable_to_non_nullable
               as ToothSide,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ScanOrder].
+extension ScanOrderPatterns on ScanOrder {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ArchScanOrder value)? arch,
+    TResult Function(QuadrantScanOrder value)? quadrant,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ArchScanOrder value) arch,
+    required TResult Function(QuadrantScanOrder value) quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder():
+        return arch(_that);
+      case QuadrantScanOrder():
+        return quadrant(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ArchScanOrder value)? arch,
+    TResult? Function(QuadrantScanOrder value)? quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Jaw jaw, Direction direction, ToothSide toothSide)? arch,
+    TResult Function(
+            Quadrant quadrant, Direction direction, ToothSide toothSide)?
+        quadrant,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that.jaw, _that.direction, _that.toothSide);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that.quadrant, _that.direction, _that.toothSide);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Jaw jaw, Direction direction, ToothSide toothSide)
+        arch,
+    required TResult Function(
+            Quadrant quadrant, Direction direction, ToothSide toothSide)
+        quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder():
+        return arch(_that.jaw, _that.direction, _that.toothSide);
+      case QuadrantScanOrder():
+        return quadrant(_that.quadrant, _that.direction, _that.toothSide);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Jaw jaw, Direction direction, ToothSide toothSide)? arch,
+    TResult? Function(
+            Quadrant quadrant, Direction direction, ToothSide toothSide)?
+        quadrant,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case ArchScanOrder() when arch != null:
+        return arch(_that.jaw, _that.direction, _that.toothSide);
+      case QuadrantScanOrder() when quadrant != null:
+        return quadrant(_that.quadrant, _that.direction, _that.toothSide);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1445,6 +2368,169 @@ class _$ChartingOrderValueCopyWithImpl<$Res>
           : order // ignore: cast_nullable_to_non_nullable
               as List<List<ScanOrder>>,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChartingOrderValue].
+extension ChartingOrderValuePatterns on ChartingOrderValue {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChartingOrderValue value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChartingOrderValue value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChartingOrderValue value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(ChartingOrderType chartingOrder, int selectedOption,
+            List<List<ScanOrder>> order)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that.chartingOrder, _that.selectedOption, _that.order);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(ChartingOrderType chartingOrder, int selectedOption,
+            List<List<ScanOrder>> order)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue():
+        return $default(_that.chartingOrder, _that.selectedOption, _that.order);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(ChartingOrderType chartingOrder, int selectedOption,
+            List<List<ScanOrder>> order)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChartingOrderValue() when $default != null:
+        return $default(_that.chartingOrder, _that.selectedOption, _that.order);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -1767,6 +2853,226 @@ class _$ProfileOOutputCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [ProfileOOutput].
+extension ProfileOOutputPatterns on ProfileOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ProfileOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ProfileOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ProfileOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilterOOutput incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSettingOOutput threshold,
+            TimerSettingOOutput timer,
+            @RfControl<bool>() bool audioGuidance)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileOOutput() when $default != null:
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilterOOutput incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSettingOOutput threshold,
+            TimerSettingOOutput timer,
+            @RfControl<bool>() bool audioGuidance)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileOOutput():
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String anotherId,
+            @RfControl<String>() String name,
+            @RfControl<ChartingOrderValue>() ChartingOrderValue chartingOrder,
+            @RfControl<NumberingStandard>() NumberingStandard numberingStandard,
+            IncidenceFilterOOutput incidenceFilter,
+            @RfControl<MeasurementType>() MeasurementType measurementType,
+            ThresholdSettingOOutput threshold,
+            TimerSettingOOutput timer,
+            @RfControl<bool>() bool audioGuidance)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ProfileOOutput() when $default != null:
+        return $default(
+            _that.id,
+            _that.anotherId,
+            _that.name,
+            _that.chartingOrder,
+            _that.numberingStandard,
+            _that.incidenceFilter,
+            _that.measurementType,
+            _that.threshold,
+            _that.timer,
+            _that.audioGuidance);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
 class _ProfileOOutput extends ProfileOOutput {
@@ -2086,6 +3392,169 @@ class _$ThresholdSettingOOutputCopyWithImpl<$Res>
   }
 }
 
+/// Adds pattern-matching-related methods to [ThresholdSettingOOutput].
+extension ThresholdSettingOOutputPatterns on ThresholdSettingOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ThresholdSettingOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ThresholdSettingOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ThresholdSettingOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingOOutput() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingOOutput():
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ThresholdSettingOOutput() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
 class _ThresholdSettingOOutput implements ThresholdSettingOOutput {
@@ -2253,6 +3722,169 @@ class _$TimerSettingOOutputCopyWithImpl<$Res>
           : value // ignore: cast_nullable_to_non_nullable
               as int,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [TimerSettingOOutput].
+extension TimerSettingOOutputPatterns on TimerSettingOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_TimerSettingOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_TimerSettingOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_TimerSettingOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingOOutput() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingOOutput():
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isEnabled, @RfControl<int>() int value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TimerSettingOOutput() when $default != null:
+        return $default(_that.isEnabled, _that.value);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -2473,6 +4105,202 @@ class _$IncidenceFilterOOutputCopyWithImpl<$Res>
           : isPlaqueEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [IncidenceFilterOOutput].
+extension IncidenceFilterOOutputPatterns on IncidenceFilterOOutput {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_IncidenceFilterOOutput value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_IncidenceFilterOOutput value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterOOutput():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_IncidenceFilterOOutput value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterOOutput() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterOOutput() when $default != null:
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterOOutput():
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool isMobilityEnabled,
+            @RfControl<bool>() bool isFurcationEnabled,
+            @RfControl<bool>() bool isBleedingEnabled,
+            @RfControl<bool>() bool isSuppurationEnabled,
+            @RfControl<bool>() bool isCalculusEnabled,
+            @RfControl<bool>() bool isPlaqueEnabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _IncidenceFilterOOutput() when $default != null:
+        return $default(
+            _that.isMobilityEnabled,
+            _that.isFurcationEnabled,
+            _that.isBleedingEnabled,
+            _that.isSuppurationEnabled,
+            _that.isCalculusEnabled,
+            _that.isPlaqueEnabled);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/profile/profile_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/profile/profile_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveProfileOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveProfileOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static ProfileOForm? of(
     BuildContext context, {
@@ -88,7 +89,7 @@ class ReactiveProfileOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -108,7 +109,7 @@ class ProfileOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -119,7 +120,8 @@ class ProfileOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, ProfileOForm formModel, Widget? child) builder;
@@ -198,11 +200,11 @@ class _ProfileOFormBuilderState extends State<ProfileOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/recursive/recursive.freezed.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/recursive/recursive.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -131,6 +130,181 @@ class _$SecuredAreaCopyWithImpl<$Res> implements $SecuredAreaCopyWith<$Res> {
     return $ParcelSystemCopyWith<$Res>(_self.parcelSystem!, (value) {
       return _then(_self.copyWith(parcelSystem: value));
     });
+  }
+}
+
+/// Adds pattern-matching-related methods to [SecuredArea].
+extension SecuredAreaPatterns on SecuredArea {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SecuredArea value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SecuredArea() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SecuredArea value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SecuredArea():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SecuredArea value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SecuredArea() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String? id,
+            SecuredArea? securedArea,
+            ParcelSystem? parcelSystem,
+            @RfArray<SecuredArea>() List<SecuredArea> subSecuredAreas)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SecuredArea() when $default != null:
+        return $default(_that.id, _that.securedArea, _that.parcelSystem,
+            _that.subSecuredAreas);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String? id,
+            SecuredArea? securedArea,
+            ParcelSystem? parcelSystem,
+            @RfArray<SecuredArea>() List<SecuredArea> subSecuredAreas)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SecuredArea():
+        return $default(_that.id, _that.securedArea, _that.parcelSystem,
+            _that.subSecuredAreas);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String? id,
+            SecuredArea? securedArea,
+            ParcelSystem? parcelSystem,
+            @RfArray<SecuredArea>() List<SecuredArea> subSecuredAreas)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SecuredArea() when $default != null:
+        return $default(_that.id, _that.securedArea, _that.parcelSystem,
+            _that.subSecuredAreas);
+      case _:
+        return null;
+    }
   }
 }
 
@@ -361,6 +535,169 @@ class _$ParcelSystemCopyWithImpl<$Res> implements $ParcelSystemCopyWith<$Res> {
   }
 }
 
+/// Adds pattern-matching-related methods to [ParcelSystem].
+extension ParcelSystemPatterns on ParcelSystem {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ParcelSystem value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystem() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ParcelSystem value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystem():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ParcelSystem value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystem() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool hasParcelSystem, ParcelSystemData data)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystem() when $default != null:
+        return $default(_that.hasParcelSystem, _that.data);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @RfControl<bool>() bool hasParcelSystem, ParcelSystemData data)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystem():
+        return $default(_that.hasParcelSystem, _that.data);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @RfControl<bool>() bool hasParcelSystem, ParcelSystemData data)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystem() when $default != null:
+        return $default(_that.hasParcelSystem, _that.data);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 class _ParcelSystem implements ParcelSystem {
@@ -515,6 +852,163 @@ class _$ParcelSystemDataCopyWithImpl<$Res>
           : id // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ParcelSystemData].
+extension ParcelSystemDataPatterns on ParcelSystemData {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ParcelSystemData value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystemData() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ParcelSystemData value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystemData():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ParcelSystemData value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystemData() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? id)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystemData() when $default != null:
+        return $default(_that.id);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? id) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystemData():
+        return $default(_that.id);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? id)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ParcelSystemData() when $default != null:
+        return $default(_that.id);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/reactive_forms_generator/example/lib/docs/recursive/recursive.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/recursive/recursive.gform.dart
@@ -53,7 +53,7 @@ class ReactiveSecuredAreaForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveSecuredAreaForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SecuredAreaForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveSecuredAreaForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -109,7 +110,7 @@ class SecuredAreaFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -120,7 +121,8 @@ class SecuredAreaFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SecuredAreaForm formModel, Widget? child) builder;
@@ -201,11 +203,11 @@ class _SecuredAreaFormBuilderState extends State<SecuredAreaFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/renamed_basic/renamed_basic.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/renamed_basic/renamed_basic.gform.dart
@@ -53,7 +53,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SomeWiredNameForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SomeWiredNameForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _SomeWiredNameFormBuilderState extends State<SomeWiredNameFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/renamed_basic/renamed_basic_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/renamed_basic/renamed_basic_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static SomeWiredNameForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveSomeWiredNameForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class SomeWiredNameFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, SomeWiredNameForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _SomeWiredNameFormBuilderState extends State<SomeWiredNameFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/user_profile/user_profile.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/user_profile/user_profile.gform.dart
@@ -53,7 +53,7 @@ class ReactiveUserProfileForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveUserProfileForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static UserProfileForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveUserProfileForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -109,7 +110,7 @@ class UserProfileFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -120,7 +121,8 @@ class UserProfileFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, UserProfileForm formModel, Widget? child) builder;
@@ -201,11 +203,11 @@ class _UserProfileFormBuilderState extends State<UserProfileFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/lib/docs/user_profile/user_profile_output.gform.dart
+++ b/packages/reactive_forms_generator/example/lib/docs/user_profile/user_profile_output.gform.dart
@@ -53,7 +53,7 @@ class ReactiveUserProfileOForm extends StatelessWidget {
     required this.form,
     required this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
   }) : super(key: key);
 
   final Widget child;
@@ -62,7 +62,8 @@ class ReactiveUserProfileOForm extends StatelessWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   static UserProfileOForm? of(
     BuildContext context, {
@@ -89,7 +90,7 @@ class ReactiveUserProfileOForm extends StatelessWidget {
       stream: form.form.statusChanged,
       child: ReactiveFormPopScope(
         canPop: canPop,
-        onPopInvoked: onPopInvoked,
+        onPopInvokedWithResult: onPopInvokedWithResult,
         child: child,
       ),
     );
@@ -110,7 +111,7 @@ class UserProfileOFormBuilder extends StatefulWidget {
     this.model,
     this.child,
     this.canPop,
-    this.onPopInvoked,
+    this.onPopInvokedWithResult,
     required this.builder,
     this.initState,
   }) : super(key: key);
@@ -121,7 +122,8 @@ class UserProfileOFormBuilder extends StatefulWidget {
 
   final bool Function(FormGroup formGroup)? canPop;
 
-  final void Function(FormGroup formGroup, bool didPop)? onPopInvoked;
+  final ReactiveFormPopInvokedWithResultCallback<dynamic>?
+      onPopInvokedWithResult;
 
   final Widget Function(
       BuildContext context, UserProfileOForm formModel, Widget? child) builder;
@@ -203,11 +205,11 @@ class _UserProfileOFormBuilderState extends State<UserProfileOFormBuilder> {
       key: ObjectKey(_formModel),
       form: _formModel,
       // canPop: widget.canPop,
-      // onPopInvoked: widget.onPopInvoked,
+      // onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: ReactiveFormBuilder(
         form: () => _formModel.form,
         canPop: widget.canPop,
-        onPopInvoked: widget.onPopInvoked,
+        onPopInvokedWithResult: widget.onPopInvokedWithResult,
         builder: (context, formGroup, child) =>
             widget.builder(context, _formModel, widget.child),
         child: widget.child,

--- a/packages/reactive_forms_generator/example/pubspec.yaml
+++ b/packages/reactive_forms_generator/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: example
 description: A new Flutter project.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   reactive_forms_annotations:
     path: ../../reactive_forms_annotations
-  reactive_forms: ^17.0.1
+  reactive_forms: ^18.1.1
   intl: ">=0.19.0 <1.0.0"
   freezed_annotation: ^3.0.0
   dartz: ^0.10.1
@@ -30,4 +30,4 @@ dev_dependencies:
   build_runner: ^2.4.15
   freezed: ^3.0.6
   json_serializable: ^6.9.5
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0

--- a/packages/reactive_forms_generator/lib/reactive_forms_generator.dart
+++ b/packages/reactive_forms_generator/lib/reactive_forms_generator.dart
@@ -84,10 +84,10 @@ class ReactiveFormsGenerator extends Generator {
       element: element,
     );
 
-    final astElement = element.enclosingElement3;
+    final astElement = element.enclosingElement;
 
     final ast = await buildStep.resolver.astNodeFor(
-      astElement ?? element,
+      (astElement ?? element).firstFragment,
       resolve: true,
     );
 

--- a/packages/reactive_forms_generator/lib/src/form_elements/form_array_generator.dart
+++ b/packages/reactive_forms_generator/lib/src/form_elements/form_array_generator.dart
@@ -17,16 +17,13 @@ class FormArrayGenerator extends FormElementGenerator {
   @override
   String get value {
     final enclosingElement =
-        (fieldElement.enclosingElement3 as ConstructorElement)
-            .enclosingElement3;
+        (fieldElement.enclosingElement as ConstructorElement).enclosingElement;
 
-    final optionalChaining = (enclosingElement == root &&
-                type?.nullabilitySuffix != NullabilitySuffix.question) ||
-            (enclosingElement == root && !root.isNullable)
-        ? ''
-        : '?';
+    final elementName = (enclosingElement.name ?? '').camelCase;
+    final fieldName = fieldElement.name ?? '';
 
-    return '(${enclosingElement.name.camelCase}$optionalChaining.${fieldElement.name}${optionalChaining != '' ? '?? []' : ''})';
+    // Always use safe navigation for nullable objects and provide empty list fallback for arrays
+    return '($elementName?.$fieldName ?? [])';
   }
 
   String get displayType {

--- a/packages/reactive_forms_generator/lib/src/form_elements/form_element_generator.dart
+++ b/packages/reactive_forms_generator/lib/src/form_elements/form_element_generator.dart
@@ -1,16 +1,14 @@
 // ignore_for_file: implementation_imports
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:reactive_forms_generator/src/extensions.dart';
 import 'package:reactive_forms_generator/src/types.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:recase/recase.dart';
 
 abstract class FormElementGenerator {
   final ClassElement root;
-  final ParameterElement field;
+  final FormalParameterElement field;
   final DartType? type;
 
   static const String validatorKey = 'validators';
@@ -18,22 +16,17 @@ abstract class FormElementGenerator {
   FormElementGenerator(this.root, this.field, this.type);
 
   String get value {
-    final enclosingElement = constructorElement.enclosingElement3;
+    final enclosingElement = constructorElement.enclosingElement;
 
-    final optionalChaining = (enclosingElement == root &&
-                type?.nullabilitySuffix != NullabilitySuffix.question) ||
-            (enclosingElement == root && !root.isNullable)
-        ? ''
-        : '?';
-
-    return '${enclosingElement.name.camelCase}$optionalChaining.${fieldElement.name}';
+    // Always use safe navigation since formElements parameter is nullable
+    return '${enclosingElement.name?.camelCase}?.${fieldElement.name}';
   }
 
   String? validatorName(ExecutableElement? e) {
     var name = e?.name;
 
     if (e is MethodElement) {
-      name = '${e.enclosingElement3.name}.$name';
+      name = '${e.enclosingElement?.name ?? ''}.${name ?? ''}';
     }
 
     return name;
@@ -58,7 +51,7 @@ abstract class FormElementGenerator {
   Element get fieldElement => field;
 
   ConstructorElement get constructorElement =>
-      fieldElement.enclosingElement3 as ConstructorElement;
+      fieldElement.enclosingElement as ConstructorElement;
 
   // Map<String, String> get annotationParams {
   //   final result = <String, String>{};

--- a/packages/reactive_forms_generator/lib/src/form_elements/form_group_generator.dart
+++ b/packages/reactive_forms_generator/lib/src/form_elements/form_group_generator.dart
@@ -13,7 +13,7 @@ class FormGroupGenerator extends FormElementGenerator {
 
   @override
   String get value {
-    final enclosingElement = constructorElement.enclosingElement3;
+    final enclosingElement = constructorElement.enclosingElement;
 
     final optionalChaining = (enclosingElement == root &&
                 type?.nullabilitySuffix != NullabilitySuffix.question) ||
@@ -21,37 +21,36 @@ class FormGroupGenerator extends FormElementGenerator {
         ? ''
         : '?';
 
-    return '${enclosingElement.name.camelCase}$optionalChaining';
+    return '${(enclosingElement.name ?? '').camelCase}$optionalChaining';
   }
 
   @override
   ConstructorElement get constructorElement =>
-      field.enclosingElement3 as ConstructorElement;
+      field.enclosingElement as ConstructorElement;
 
   @override
   Element get fieldElement => field.type.element!;
 
   ClassElement get classElement => field.type.element as ClassElement;
 
-  List<ParameterElement> get formElements => classElement.constructors
+  List<FormalParameterElement> get formElements => classElement.constructors
       .where((e) => e.hasReactiveFormAnnotatedParameters)
       .first
-      .parameters
+      .formalParameters
       .where(
         (e) => (e.isFormControl || e.isFormArray || e.isFormGroupArray),
       )
       .toList();
 
-  List<ParameterElement> get nestedFormElements => classElement.constructors
-      .where((e) => e.hasReactiveFormAnnotatedParameters)
-      .first
-      .parameters
-      .where((e) => e.isFormGroup)
-      .toList();
+  List<FormalParameterElement> get nestedFormElements =>
+      classElement.constructors
+          .where((e) => e.hasReactiveFormAnnotatedParameters)
+          .first
+          .formalParameters
+          .where((e) => e.isFormGroup)
+          .toList();
 
-  // String get validators => syncValidators(formControlChecker);
-
-  // String get asyncValidators => asyncValidatorList(formGroupChecker);
+  // Use inherited validators implementation from FormElementGenerator
 
   @override
   String element() {
@@ -81,7 +80,7 @@ class FormGroupGenerator extends FormElementGenerator {
     formElementsList.addAll(
       nestedFormElements.map(
         (f) {
-          return '${f.fieldControlNameName}: ${f.className}.formElements($value.${f.name})';
+          return '${f.fieldControlNameName}: ${f.className}.formElements($value.${f.name ?? ''})';
         },
       ),
     );

--- a/packages/reactive_forms_generator/lib/src/output/extensions.dart
+++ b/packages/reactive_forms_generator/lib/src/output/extensions.dart
@@ -169,7 +169,7 @@ extension TypeAnnotationImplExt on TypeAnnotationImpl {
       final GenericFunctionTypeImpl _ => this,
       final NamedTypeImpl _ => NamedTypeImpl(
           importPrefix: type.importPrefix,
-          name2: type.name2,
+          name: type.name,
           typeArguments: type.typeArguments,
           question: null,
         ),
@@ -184,13 +184,13 @@ extension TypeAnnotationImplExt on TypeAnnotationImpl {
       GenericFunctionTypeImpl() => throw UnimplementedError(),
       NamedTypeImpl() => NamedTypeImpl(
           importPrefix: type.importPrefix,
-          name2: type.element?.hasRfGroupAnnotation == true
+          name: type.element?.hasRfGroupAnnotation == true
               ? StringToken(
                   TokenType.STRING,
-                  '${type.name2.lexeme}Output',
+                  '${type.name.lexeme}Output',
                   0,
                 )
-              : type.name2,
+              : type.name,
           typeArguments: type.typeArguments?.newTypeArguments,
           question: type.question,
         ),
@@ -220,7 +220,7 @@ extension FieldDeclarationImplExt on FieldDeclarationImpl {
         covariantKeyword: covariantKeyword,
         externalKeyword: externalKeyword,
         staticKeyword: staticKeyword,
-        fieldList: VariableDeclarationListImpl(
+        fields: VariableDeclarationListImpl(
           comment: null,
           metadata: fields.metadata,
           lateKeyword: fields.lateKeyword,

--- a/packages/reactive_forms_generator/lib/src/output/rf_annotation_arguments_visitor.dart
+++ b/packages/reactive_forms_generator/lib/src/output/rf_annotation_arguments_visitor.dart
@@ -72,9 +72,9 @@ class ClassRenameVisitor extends GeneralizingAstVisitor<void> {
                   (e) {
                     return NamedTypeImpl(
                       importPrefix: e.importPrefix,
-                      name2: StringToken(
+                      name: StringToken(
                         TokenType.STRING,
-                        '${e.name2.lexeme}Output',
+                        '${e.name.lexeme}Output',
                         0,
                       ),
                       typeArguments: e.typeArguments,
@@ -97,7 +97,7 @@ class ClassRenameVisitor extends GeneralizingAstVisitor<void> {
                 constKeyword: e.constKeyword,
                 factoryKeyword: e.factoryKeyword,
                 returnType: SimpleIdentifierImpl(
-                  StringToken(
+                  token: StringToken(
                     TokenType.STRING,
                     '${e.returnType.name}Output',
                     0,
@@ -113,9 +113,9 @@ class ClassRenameVisitor extends GeneralizingAstVisitor<void> {
                         type: NamedTypeImpl(
                           importPrefix:
                               e.redirectedConstructor!.type.importPrefix,
-                          name2: StringToken(
+                          name: StringToken(
                             TokenType.STRING,
-                            '${e.redirectedConstructor!.type.name2}Output',
+                            '${e.redirectedConstructor!.type.name}Output',
                             0,
                           ),
                           typeArguments:
@@ -145,7 +145,7 @@ class ClassRenameVisitor extends GeneralizingAstVisitor<void> {
                                     .expression as MethodInvocationImpl)
                                 .operator,
                             methodName: SimpleIdentifierImpl(
-                              StringToken(
+                              token: StringToken(
                                 TokenType.STRING,
                                 ((e.body as ExpressionFunctionBodyImpl)
                                         .expression as MethodInvocationImpl)
@@ -183,7 +183,7 @@ class ClassRenameVisitor extends GeneralizingAstVisitor<void> {
                 covariantKeyword: e.covariantKeyword,
                 externalKeyword: e.externalKeyword,
                 staticKeyword: e.staticKeyword,
-                fieldList: VariableDeclarationListImpl(
+                fields: VariableDeclarationListImpl(
                   comment: null,
                   metadata: e.fields.metadata,
                   lateKeyword: e.fields.lateKeyword,
@@ -377,7 +377,7 @@ class ClassRenameVisitor extends GeneralizingAstVisitor<void> {
         constKeyword: node.constKeyword,
         factoryKeyword: node.factoryKeyword,
         returnType: SimpleIdentifierImpl(
-          StringToken(
+          token: StringToken(
             TokenType.STRING,
             '${node.returnType.name}Output',
             0,

--- a/packages/reactive_forms_generator/lib/src/output/rf_paramater_visitor.dart
+++ b/packages/reactive_forms_generator/lib/src/output/rf_paramater_visitor.dart
@@ -43,15 +43,15 @@ class RfParameterVisitor extends GeneralizingAstVisitor<dynamic> {
       case DefaultFormalParameterImpl():
         // final p = node;
         final hasDefaultValue =
-            node.parameter.declaredElement?.hasDefaultValue == true;
+            node.parameter.declaredFragment?.element.hasDefaultValue == true;
         final hasDefaultAnnotation = node.parameter.metadata.fold(
             false, (acc, e) => acc || e.name.toString().startsWith('Default'));
 
-        final hasRfGroupAnnotation = node.parameter.declaredElement?.type
-                .element?.hasRfGroupAnnotation ==
+        final hasRfGroupAnnotation = node.parameter.declaredFragment?.element
+                .type.element?.hasRfGroupAnnotation ==
             true;
 
-        final type = node.parameter.declaredElement?.type;
+        final type = node.parameter.declaredFragment?.element.type;
         final isList = type != null &&
             type.isDartCoreList == true &&
             type is ParameterizedType &&
@@ -180,15 +180,15 @@ class RfParameterVisitor2 extends GeneralizingAstVisitor<dynamic> {
     final element = node.element;
     if (node is NamedTypeImpl &&
         element is ClassElementImpl &&
-        element.metadata.hasRfGroupAnnotation) {
+        element.firstFragment.element.hasRfGroupAnnotation) {
       try {
         NodeReplacer.replace(
             node,
             NamedTypeImpl(
               importPrefix: node.importPrefix,
-              name2: StringToken(
+              name: StringToken(
                 TokenType.STRING,
-                '${node.name2}Output',
+                '${node.name}Output',
                 0,
               ),
               typeArguments: node.typeArguments,

--- a/packages/reactive_forms_generator/lib/src/reactive_form_generator_method.dart
+++ b/packages/reactive_forms_generator/lib/src/reactive_form_generator_method.dart
@@ -4,7 +4,7 @@ import 'package:reactive_forms_generator/src/extensions.dart';
 import 'package:reactive_forms_generator/src/types.dart';
 
 abstract class ReactiveFormGeneratorMethod {
-  final ParameterElement field;
+  final FormalParameterElement field;
   final bool output;
   final List<String> requiredValidators;
 

--- a/packages/reactive_forms_generator/lib/src/reactive_forms/reactive_form.dart
+++ b/packages/reactive_forms_generator/lib/src/reactive_forms/reactive_form.dart
@@ -45,7 +45,7 @@ class ReactiveForm {
               ),
               Parameter(
                 (b) => b
-                  ..name = 'onPopInvoked'
+                  ..name = 'onPopInvokedWithResult'
                   ..toThis = true
                   ..named = true,
               ),
@@ -88,10 +88,10 @@ class ReactiveForm {
             ),
             Field(
               (b) => b
-                ..name = 'onPopInvoked'
+                ..name = 'onPopInvokedWithResult'
                 ..modifier = FieldModifier.final$
                 ..type = const Reference(
-                    'void Function(FormGroup formGroup, bool didPop)?'),
+                    'ReactiveFormPopInvokedWithResultCallback<dynamic>?'),
             ),
           ])
           ..methods.addAll(
@@ -154,7 +154,7 @@ class ReactiveForm {
                       stream: form.form.statusChanged,
                       child: ReactiveFormPopScope(
                         canPop: canPop,
-                        onPopInvoked: onPopInvoked,
+                        onPopInvokedWithResult: onPopInvokedWithResult,
                         child: child,
                       ),
                     );

--- a/packages/reactive_forms_generator/lib/src/reactive_forms/reactive_form_builder.dart
+++ b/packages/reactive_forms_generator/lib/src/reactive_forms/reactive_form_builder.dart
@@ -69,7 +69,7 @@ class ReactiveFormBuilder {
               ),
               Parameter(
                 (b) => b
-                  ..name = 'onPopInvoked'
+                  ..name = 'onPopInvokedWithResult'
                   ..named = true
                   ..toThis = true,
               ),
@@ -115,9 +115,9 @@ class ReactiveFormBuilder {
         ),
         Field(
           (b) => b
-            ..name = 'onPopInvoked'
+            ..name = 'onPopInvokedWithResult'
             ..type = const Reference(
-                'void Function(FormGroup formGroup, bool didPop)?')
+                'ReactiveFormPopInvokedWithResultCallback<dynamic>?')
             ..modifier = FieldModifier.final$,
         ),
         Field(
@@ -244,11 +244,11 @@ class ReactiveFormBuilder {
                   key: ObjectKey(_formModel),
                   form: _formModel,
                   // canPop: widget.canPop,
-                  // onPopInvoked: widget.onPopInvoked,
+                  // onPopInvokedWithResult: widget.onPopInvokedWithResult,
                   child: ReactiveFormBuilder(
                     form: () => _formModel.form,
                     canPop: widget.canPop,
-                    onPopInvoked: widget.onPopInvoked,
+                    onPopInvokedWithResult: widget.onPopInvokedWithResult,
                     builder: (context, formGroup, child) => widget.builder(context, _formModel, widget.child),
                     child: widget.child,
                   ),

--- a/packages/reactive_forms_generator/lib/src/types.dart
+++ b/packages/reactive_forms_generator/lib/src/types.dart
@@ -96,7 +96,7 @@ extension ElementRfExt on Element {
     final annotation = typeChecker?.firstAnnotationOf(this);
     try {
       if (annotation != null) {
-        for (final meta in metadata) {
+        for (final meta in metadata.annotations) {
           final obj = meta.computeConstantValue()!;
 
           if (typeChecker?.isExactlyType(obj.type!) == true) {
@@ -125,7 +125,7 @@ extension ElementRfExt on Element {
   }
 }
 
-extension ParameterElementAnnotationExt on ParameterElement {
+extension ParameterElementAnnotationExt on FormalParameterElement {
   bool get hasRfAnnotation {
     return _formChecker.hasAnnotationOfExact(this);
   }

--- a/packages/reactive_forms_generator/pubspec.yaml
+++ b/packages/reactive_forms_generator/pubspec.yaml
@@ -2,17 +2,17 @@ name: reactive_forms_generator
 description: Generator for reactive_forms. Generates form classes based on model.
 repository: https://github.com/artflutter/reactive_forms_generator
 
-version: 7.0.6
+version: 8.0.4
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
 resolution: workspace
 
 dependencies:
-  build: ^2.4.2
-  source_gen: ^2.0.0
-  _fe_analyzer_shared: ^80.0.0
-  analyzer: ^7.3.0
+  build: ^4.0.1
+  source_gen: ^4.0.1
+  _fe_analyzer_shared: ^89.0.0
+  analyzer: ^8.2.0
   path: ^1.8.1
   build_runner: ^2.4.15
   code_builder: ^4.10.1
@@ -21,9 +21,9 @@ dependencies:
   recase: ^4.1.0
 
 dev_dependencies:
-  build_test: ^2.2.3
+  build_test: ^3.4.1
   logging: ^1.2.0
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 #dependency_overrides:
 #  build_resolvers: ^2.1.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,21 +2,21 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   _fe_analyzer_shared:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: _fe_analyzer_shared
-      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
+      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
       url: "https://pub.dev"
     source: hosted
-    version: "80.0.0"
+    version: "89.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer
-      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
+      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "8.2.0"
   ansi_styles:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "825fed4d63050252a0b6e74f2d75844c4a85b664814be6993bd3493fb5239779"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "4.0.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
@@ -73,38 +73,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: "4e54dbeefdc70691ba80b3bce3976af63b5425c8c07dface348dfee664a0edc1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.0"
+    version: "2.9.0"
   build_test:
     dependency: transitive
     description:
       name: build_test
-      sha256: a580c76c28440d0006b75c6746bbbb3c1648959ba9e1afae2c2b0f2c26acdf3d
+      sha256: e2c97c203e4ff8871fd4bc7b4d7a879f991214d505ba29386e90c5bfb6202acf
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "3.4.1"
   built_collection:
     dependency: transitive
     description:
@@ -117,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.12.0"
   characters:
     dependency: transitive
     description:
@@ -141,18 +125,26 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_launcher:
     dependency: transitive
     description:
       name: cli_launcher
-      sha256: "5e7e0282b79e8642edd6510ee468ae2976d847a0a29b3916e85f5fa1bfe24005"
+      sha256: "17d2744fb9a254c49ec8eda582536abe714ea0131533e24389843a4256f82eac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "0.3.2+1"
   cli_util:
     dependency: transitive
     description:
@@ -173,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: transitive
     description:
@@ -189,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: conventional_commit
-      sha256: dec15ad1118f029c618651a4359eb9135d8b88f761aa24e4016d061cd45948f2
+      sha256: c40b1b449ce2a63fa2ce852f35e3890b1e182f5951819934c0e4a66254bc0dc3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0+1"
+    version: "0.6.1+1"
   convert:
     dependency: transitive
     description:
@@ -205,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -229,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   dartz:
     dependency: transitive
     description:
@@ -282,10 +274,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -300,18 +292,18 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
+      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.2.3"
   freezed_annotation:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -340,18 +332,18 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.5"
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -388,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -404,42 +396,42 @@ packages:
     dependency: transitive
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.11.1"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.0"
   logging:
     dependency: transitive
     description:
@@ -468,10 +460,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "63e9852a28a44c811503b31c607606f9ce8d891e22879e1e97fc7417c22ed6bc"
+      sha256: "7edaa77edb2017dd0c05b5e1baa501965903c5d6f314dfc096df36ada5275199"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0-dev.7"
+    version: "7.1.1"
   meta:
     dependency: transitive
     description:
@@ -492,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: mustache_template
-      sha256: a46e26f91445bfb0b60519be280555b06792460b27b19e2b19ad5b9740df5d1c
+      sha256: d9aa84d114368b7f1727b7014b85bb0b234daeafe1518824c82d32703b3964f6
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   nested:
     dependency: transitive
     description:
@@ -516,10 +508,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
@@ -540,18 +532,18 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   process:
     dependency: transitive
     description:
       name: process
-      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.0.5"
   prompts:
     dependency: transitive
     description:
@@ -564,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   pub_updater:
     dependency: transitive
     description:
@@ -588,18 +580,18 @@ packages:
     dependency: transitive
     description:
       name: reactive_forms
-      sha256: "9b1fb18e0aae9c50cfa0aaabaaa38bc4d78eefc9b7b95fa9c947b051f6524b8e"
+      sha256: "4c8fe71f21ac88996c01a56fe19ea5ec39b47292cb07f99a467e1bb977136a98"
       url: "https://pub.dev"
     source: hosted
-    version: "17.0.1"
+    version: "18.1.1"
   reactive_forms_lbc:
     dependency: transitive
     description:
       name: reactive_forms_lbc
-      sha256: "62e714eef3e257b1f51111f7b1f92d5a2ecb96ecc531efd95e4c24e4b9a6b6c5"
+      sha256: "908a0a0cacb650838c01a88661836ef11386675a261f6c8f53881896a36ea0ac"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.6"
   recase:
     dependency: transitive
     description:
@@ -649,18 +641,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: ccf30b0c9fbcd79d8b6f5bfac23199fb354938436f62475e14aea0f29ee0f800
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.0.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5"
+    version: "1.3.8"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -729,34 +721,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.2"
   test_api:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
+    version: "0.6.11"
   typed_data:
     dependency: transitive
     description:
@@ -769,50 +753,50 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.4"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -838,5 +822,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,6 @@ workspace:
 environment:
   sdk: ">=3.6.0 <4.0.0"
 
-dependency_overrides:
-  test_api: 0.7.4
-
 dev_dependencies:
   build_runner: ^2.4.15
   melos: ^7.0.0-dev.7


### PR DESCRIPTION
- Updated Dart SDK version to >=3.9.0 and Flutter version to >=3.29.0 in pubspec.lock.
- Updated flutter_lints dependency to version ^6.0.0 in multiple pubspec.yaml files.
- Enhanced test cases in generator_tests to include onPopInvokedWithResult functionality in various output classes.
- Minor adjustments in generator code to ensure consistency and improve readability.