### PR TITLE
Fix errors method return type (#204)

### DIFF
--- a/packages/reactive_forms_generator/lib/src/reactive_forms_generator/errors_method.dart
+++ b/packages/reactive_forms_generator/lib/src/reactive_forms_generator/errors_method.dart
@@ -11,7 +11,7 @@ class ErrorsMethod extends ReactiveFormGeneratorMethod {
       ..name = field.errorsMethodName
       ..lambda = true
       ..type = MethodType.getter
-      ..returns = Reference('Map<String, Object>${field.nullabilitySuffix}')
+      ..returns = Reference('Map<String, dynamic>${field.nullabilitySuffix}')
       ..body = Code('${field.fieldControlName}.errors'),
   );
 }


### PR DESCRIPTION
Since `reactive_forms` v18.2.2 the return type of errors is `Map<String, dynamic>`.

Fixes #204 